### PR TITLE
Surface unassigned keyboard shortcuts in the popup

### DIFF
--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -42,6 +42,9 @@ export function Popup() {
       });
       setShortcuts(currentShortcuts);
       setShortcutsLoaded(true);
+    }).catch(() => {
+      // Commands API unavailable: keep manifest defaults and no warning,
+      // since we cannot verify which keys are actually assigned.
     });
   });
 
@@ -142,7 +145,7 @@ export function Popup() {
       <section className="popup-shortcuts" aria-label="Keyboard shortcuts">
         {shortcutsLoaded && unsetCommands.length > 0 && (
           <p className="popup-shortcut-warning" role="alert">
-            <InfoIcon size={14} aria-hidden="true" />
+            <InfoIcon size={14} />
             <span>
               {unsetCommands.length === 1
                 ? "Shortcut not assigned: "

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { openShortcutSettings } from "../browser";
-import { ArrowUpRightIcon, CommandIcon } from "../icons";
+import { CommandIcon, ArrowUpRightIcon, InfoIcon } from "../icons";
 import { DEFAULT_SETTINGS, getStoredSettings, saveStoredSettings } from "../settings";
 import type { TabSwitchMode, UserSettings } from "../types";
 import { resolveSettingsRead } from "./settingsState";
@@ -9,6 +9,7 @@ import { useMountEffect } from "../hooks/useMountEffect";
 export function Popup() {
   const [settings, setSettings] = useState<UserSettings>(DEFAULT_SETTINGS);
   const [shortcuts, setShortcuts] = useState<Record<string, string>>({});
+  const [shortcutsLoaded, setShortcutsLoaded] = useState(false);
   const settingsRevision = useRef(0);
   const isMac = typeof navigator !== "undefined" && navigator.platform.includes("Mac");
   const defaultSearchShortcut = isMac ? "⌘⇧P" : "Ctrl Shift P";
@@ -40,8 +41,24 @@ export function Popup() {
         if (command.name && command.shortcut) currentShortcuts[command.name] = command.shortcut;
       });
       setShortcuts(currentShortcuts);
+      setShortcutsLoaded(true);
     });
   });
+
+  const shortcutRows = [
+    { label: "Search tabs", command: "open-palette" as const, fallback: defaultSearchShortcut },
+    { label: "Visual switcher", command: "open-tab-switcher" as const, fallback: defaultSwitcherShortcut },
+    { label: "Pin selected tab", command: "pin-tab" as const, fallback: defaultPinShortcut },
+  ];
+  const unsetCommands = shortcutRows.filter((row) => !shortcuts[row.command]);
+
+  const openShortcutSettingsAndClose = async () => {
+    try {
+      await openShortcutSettings();
+    } finally {
+      window.close();
+    }
+  };
 
   const updateSetting = async <K extends keyof UserSettings>(key: K, value: UserSettings[K]) => {
     const saveRevision = settingsRevision.current + 1;
@@ -123,37 +140,37 @@ export function Popup() {
       </section>
 
       <section className="popup-shortcuts" aria-label="Keyboard shortcuts">
-        <div className="popup-shortcut-row">
-          <span>Search tabs</span>
-          <span className="popup-key-group">
-            <kbd>{shortcuts["open-palette"] ?? defaultSearchShortcut}</kbd>
-          </span>
-        </div>
-        <div className="popup-shortcut-row">
-          <span>Visual switcher</span>
-          <span className="popup-key-group">
-            <kbd>{shortcuts["open-tab-switcher"] ?? defaultSwitcherShortcut}</kbd>
-          </span>
-        </div>
-        <div className="popup-shortcut-row">
-          <span>Pin selected tab</span>
-          <span className="popup-key-group">
-            <kbd>{shortcuts["pin-tab"] ?? defaultPinShortcut}</kbd>
-          </span>
-        </div>
+        {shortcutsLoaded && unsetCommands.length > 0 && (
+          <p className="popup-shortcut-warning" role="alert">
+            <InfoIcon size={14} aria-hidden="true" />
+            <span>
+              {unsetCommands.length === 1
+                ? "Shortcut not assigned: "
+                : "Shortcuts not assigned: "}
+              {unsetCommands.map((row) => row.label).join(", ")}.
+            </span>
+            <button type="button" onClick={() => void openShortcutSettingsAndClose()}>
+              Fix it
+            </button>
+          </p>
+        )}
+        {shortcutRows.map((row) => (
+          <div key={row.command} className="popup-shortcut-row">
+            <span>{row.label}</span>
+            <span className="popup-key-group">
+              <kbd className={shortcutsLoaded && !shortcuts[row.command] ? "popup-key-unset" : undefined}>
+                {shortcuts[row.command] ?? (shortcutsLoaded ? "Not set" : row.fallback)}
+              </kbd>
+            </span>
+          </div>
+        ))}
       </section>
 
       <footer className="popup-footer-bar">
         <button
           type="button"
           className="popup-settings-link"
-          onClick={async () => {
-            try {
-              await openShortcutSettings();
-            } finally {
-              window.close();
-            }
-          }}
+          onClick={() => void openShortcutSettingsAndClose()}
         >
           <span>Customize shortcuts</span>
           <ArrowUpRightIcon size={11} />

--- a/src/styles.css
+++ b/src/styles.css
@@ -1175,7 +1175,7 @@ kbd {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.1);
 }
 
-/* ponytail: fixed amber instead of per-theme warning tokens; readable on all shipped themes */
+/* ponytail: fixed amber for the dark themes; light themes override below */
 .popup-shortcut-warning {
   display: flex;
   align-items: flex-start;
@@ -1332,6 +1332,12 @@ kbd {
 
 /* Default theme follows the browser's light appearance. */
 @media (prefers-color-scheme: light) {
+  .popup-shortcut-warning {
+    border-color: rgba(180, 83, 9, 0.35);
+    background: rgba(180, 83, 9, 0.08);
+    color: #92400e;
+  }
+
   .palette-backdrop[data-theme="default"] {
     background: rgba(255, 255, 255, 0.42);
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1175,6 +1175,39 @@ kbd {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.1);
 }
 
+/* ponytail: fixed amber instead of per-theme warning tokens; readable on all shipped themes */
+.popup-shortcut-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin: 0 0 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  background: rgba(251, 191, 36, 0.1);
+  color: #fbbf24;
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+.popup-shortcut-warning button {
+  margin-left: auto;
+  flex-shrink: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-weight: 650;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.popup-key-group kbd.popup-key-unset {
+  color: var(--text-muted);
+  border-style: dashed;
+}
+
 .popup-footer-bar {
   padding: 4px 12px 10px;
 }


### PR DESCRIPTION
## What this PR does

The popup's Keyboard shortcuts section already read `chrome.commands.getAll()`, but it only used the result to *display* keys. When a command ends up with no key bound, the popup silently showed the manifest `suggested_key` (e.g. `Ctrl Shift P`) even though the shortcut does nothing when pressed. Users have no way to discover that their shortcut is missing, and the fix lives two menus deep in `chrome://extensions/shortcuts`.

This PR makes the popup surface that state.

## Why shortcuts end up unbound

Chrome applies `suggested_key` once at first install, first-come-first-served:

- If the combo is already taken (another extension, or a browser-internal shortcut like `Ctrl+Shift+P` on Windows/Linux, which is the system print dialog), the assignment is skipped with no warning.
- If the user ever changes or clears a command's key, Chrome sets a per-command "user modified" flag and never auto-assigns that command again, even if the key becomes free.
- A brand-new command in an update (like `pin-tab` added in 0.1.4) has no such state and gets its key assigned automatically, which is why some rows are bound and others are not.

None of this is visible to the user until they press a key and nothing happens.

## Changes

- `src/popup/Popup.tsx`
  - The three shortcut rows render from a single `shortcutRows` list (was three hardcoded blocks).
  - When a named command has no binding, its chip now shows a dashed "Not set" instead of the manifest default.
  - While `getAll()` is still in flight the defaults are shown (no flicker); a `shortcutsLoaded` flag gates the "Not set" state.
  - If any command is unassigned, an amber warning row appears: "Shortcuts not assigned: Visual switcher. **Fix it**", which opens `chrome://extensions/shortcuts` via the existing `openShortcutSettings` message and closes the popup.
  - The footer "Customize shortcuts" button now shares the same open-and-close helper.
- `src/styles.css`
  - `.popup-shortcut-warning` (amber banner, inherits per-theme text styles for the icon), and `.popup-key-unset` (muted dashed kbd). Fixed amber on purpose, marked with a `ponytail:` comment, since the theme blocks define no warning tokens.

## Behavior

| State | Before | After |
|---|---|---|
| Shortcut bound | Shows bound key | Same |
| Shortcut unbound, `getAll()` pending | Shows manifest default | Shows manifest default |
| Shortcut unbound, loaded | Shows manifest default (false) | Dashed "Not set" + warning row with one-click fix |

## Verification

- `pnpm build` passes (`tsc --noEmit` + both Vite builds).
- `pnpm test`: 13/13 pass.
- No lint/format scripts in `package.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces unassigned keyboard shortcuts in the popup so users no longer see a shortcut that does nothing. The popup now shows a dashed "Not set" chip and an amber warning with a one-click fix instead of the manifest's suggested key.

**Bug Fixes**
- Shows a dashed "Not set" chip instead of the manifest default when a command has no key bound.
- Adds an amber warning row with a "Fix it" button that opens `chrome://extensions/shortcuts` and closes the popup.
- Waits for `chrome.commands.getAll()` to finish before showing "Not set"; if the call fails, defaults stay and no warning shows.
- Uses a darker amber on light themes so the warning meets WCAG AA contrast.

<sup>Written for commit 00b4646bba5e390606971fa158747a82cb6d3658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DeepanshuMishraa/jump/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shortcut settings now show loading placeholders, assigned shortcuts, or “Not set” when no shortcut is configured.
  * Added a warning for unassigned shortcuts with a direct “Fix it” option.
  * Shortcut settings navigation is now available from the warning and settings link.

* **Style**
  * Added visual styling for shortcut warnings and unset shortcut values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->