### PR TITLE
fix: speed up overlays and restore tab previews

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["tabs", "windows", "storage", "search", "history"],
+  "permissions": ["activeTab", "tabs", "windows", "storage", "search", "history"],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,6 @@
     "128": "icons/icon128.png"
   },
   "permissions": ["activeTab", "tabs", "windows", "storage", "search", "history"],
-  "host_permissions": ["<all_urls>"],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,7 @@
     "128": "icons/icon128.png"
   },
   "permissions": ["activeTab", "tabs", "windows", "storage", "search", "history"],
+  "host_permissions": ["<all_urls>"],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["activeTab", "tabs", "windows", "storage", "search", "history"],
+  "permissions": ["activeTab", "tabs", "windows", "storage", "search", "history", "bookmarks"],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
@@ -53,12 +53,12 @@
       },
       "description": "Pin or unpin the selected tab"
     },
-    "mute-tab": {
+    "open-bookmarks": {
       "suggested_key": {
-        "default": "Alt+M",
-        "mac": "Alt+M"
+        "default": "Alt+B",
+        "mac": "Alt+B"
       },
-      "description": "Mute or unmute the selected tab in the command palette"
+      "description": "Open the bookmark manager"
     }
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ArrowRightIcon, InfoIcon, PinIcon, SearchIcon, XIcon } from "./icons";
 import { PaletteAction } from "./PaletteAction";
 import { canStartPaletteDrag } from "./paletteDrag";
 import { buildSearchResults, type SearchResult } from "./paletteSearch";
+import { stalePreviewTabIds } from "./previewCache";
 import { getSearchHistory, recordSearch, type SearchHistoryEntry } from "./searchHistory";
 import { DEFAULT_SETTINGS, getStoredSettings, pinnedTabIdentity, saveStoredSettings, subscribeToSettings } from "./settings";
 import { useMountEffect } from "./hooks/useMountEffect";
@@ -29,6 +30,9 @@ export function App({
   const [settings, setSettings] = useState<UserSettings>(DEFAULT_SETTINGS);
   const [previewUrls, setPreviewUrls] = useState<Record<string, string>>({});
   const requestedPreviewIds = useRef(new Set<number>());
+  const requestedPreviewUrls = useRef(new Map<number, string>());
+  const previewRequestSequence = useRef(0);
+  const previewRequestVersions = useRef(new Map<number, number>());
   const [isDraggingPalette, setIsDraggingPalette] = useState(false);
   const [isPaletteDragReady, setIsPaletteDragReady] = useState(false);
   const paletteDragModifierRef = useRef(false);
@@ -83,15 +87,65 @@ export function App({
   const historySearchTimerRef = useRef<number | undefined>(undefined);
   const historyRequestIdRef = useRef(0);
   const requestTabPreviews = useCallback((tabIds: number[]) => {
-    const missingTabIds = tabIds.filter((tabId) => !requestedPreviewIds.current.has(tabId));
+    const currentTabUrls = new Map(tabsRef.current.map((tab) => [tab.id, tab.url]));
+    const missingTabIds = tabIds.filter((tabId) => {
+      const currentUrl = currentTabUrls.get(tabId);
+      if (currentUrl === undefined) return false;
+      if (!requestedPreviewIds.current.has(tabId)) return true;
+      if (requestedPreviewUrls.current.get(tabId) === currentUrl) return false;
+      requestedPreviewIds.current.delete(tabId);
+      previewRequestVersions.current.delete(tabId);
+      requestedPreviewUrls.current.delete(tabId);
+      return true;
+    });
     if (missingTabIds.length === 0) return;
-    missingTabIds.forEach((tabId) => requestedPreviewIds.current.add(tabId));
+
+    const requestVersion = previewRequestSequence.current + 1;
+    previewRequestSequence.current = requestVersion;
+    const requestedUrls = new Map(missingTabIds.map((tabId) => [tabId, currentTabUrls.get(tabId)]));
+    missingTabIds.forEach((tabId) => {
+      requestedPreviewIds.current.add(tabId);
+      requestedPreviewUrls.current.set(tabId, requestedUrls.get(tabId) ?? "");
+      previewRequestVersions.current.set(tabId, requestVersion);
+    });
+
     void getTabPreviews(missingTabIds).then((previews) => {
-      if (Object.keys(previews).length > 0) {
-        setPreviewUrls((current) => ({ ...current, ...previews }));
+      const validPreviews = Object.fromEntries(Object.entries(previews).filter(([tabId]) => {
+        const numericTabId = Number(tabId);
+        const currentTab = tabsRef.current.find((tab) => tab.id === numericTabId);
+        return previewRequestVersions.current.get(numericTabId) === requestVersion &&
+          currentTab?.url === requestedUrls.get(numericTabId);
+      }));
+      if (Object.keys(validPreviews).length > 0) {
+        setPreviewUrls((current) => ({ ...current, ...validPreviews }));
       }
+      missingTabIds.forEach((tabId) => {
+        if (!(String(tabId) in previews) && previewRequestVersions.current.get(tabId) === requestVersion) {
+          requestedPreviewIds.current.delete(tabId);
+          requestedPreviewUrls.current.delete(tabId);
+          previewRequestVersions.current.delete(tabId);
+        }
+      });
     }).catch(() => {
-      missingTabIds.forEach((tabId) => requestedPreviewIds.current.delete(tabId));
+      missingTabIds.forEach((tabId) => {
+        requestedPreviewIds.current.delete(tabId);
+        requestedPreviewUrls.current.delete(tabId);
+        previewRequestVersions.current.delete(tabId);
+      });
+    });
+  }, []);
+
+  const invalidateTabPreviews = useCallback((tabIds: number[]) => {
+    if (tabIds.length === 0) return;
+    tabIds.forEach((tabId) => {
+      requestedPreviewIds.current.delete(tabId);
+      requestedPreviewUrls.current.delete(tabId);
+      previewRequestVersions.current.delete(tabId);
+    });
+    setPreviewUrls((current) => {
+      const next = { ...current };
+      tabIds.forEach((tabId) => delete next[String(tabId)]);
+      return next;
     });
   }, []);
 
@@ -127,7 +181,6 @@ export function App({
   const handleClose = useCallback(() => {
     if (isClosingRef.current) return;
     isClosingRef.current = true;
-    void notifyPaletteClosed().catch(() => undefined);
     setIsClosing(true);
     setTimeout(() => {
       onClose();
@@ -141,6 +194,9 @@ export function App({
     try {
       const tabList = await getTabs();
       if (requestId !== tabsRequestIdRef.current) return;
+      const staleTabIds = stalePreviewTabIds(tabsRef.current, tabList);
+      invalidateTabPreviews(staleTabIds);
+      tabsRef.current = tabList;
       setTabs(tabList);
       if (isSwitcher && initialSwitcherSelectionPending.current && tabList.length > 0) {
         const activeIndex = initialActiveTabId === undefined
@@ -152,7 +208,7 @@ export function App({
     } catch {
       if (requestId === tabsRequestIdRef.current) setTabs([]);
     }
-  }, [isSwitcher, initialActiveTabId]);
+  }, [initialActiveTabId, invalidateTabPreviews, isSwitcher]);
   refreshTabsRef.current = refreshTabs;
 
   useMountEffect(() => {
@@ -171,15 +227,20 @@ export function App({
         ? [
             chrome.tabs.onCreated,
             chrome.tabs.onRemoved,
-            chrome.tabs.onUpdated,
             chrome.tabs.onActivated,
             chrome.windows.onFocusChanged,
           ]
         : [];
+    const handleTabUpdated = (tabId: number, changeInfo: { url?: string }) => {
+      if (changeInfo.url !== undefined) invalidateTabPreviews([tabId]);
+      scheduleRefresh();
+    };
     events.forEach((event) => event.addListener(scheduleRefresh));
+    chrome.tabs?.onUpdated.addListener(handleTabUpdated);
     return () => {
       if (refreshTimer !== undefined) window.clearTimeout(refreshTimer);
       events.forEach((event) => event.removeListener(scheduleRefresh));
+      chrome.tabs?.onUpdated.removeListener(handleTabUpdated);
     };
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useLayoutEffect, useMemo, useRef, useState, type KeyboardE
 import { activateTab, getBrowserHistory, getTabPreviews, getTabs, notifyPaletteClosed, notifyPaletteOpened, openUrl, searchWeb, setTabMuted, setTabPinned, type BrowserHistoryItem } from "./browser";
 import { ArrowRightIcon, InfoIcon, PinIcon, SearchIcon, XIcon } from "./icons";
 import { PaletteAction } from "./PaletteAction";
+import { canStartPaletteDrag } from "./paletteDrag";
 import { buildSearchResults, type SearchResult } from "./paletteSearch";
 import { getSearchHistory, recordSearch, type SearchHistoryEntry } from "./searchHistory";
 import { DEFAULT_SETTINGS, getStoredSettings, pinnedTabIdentity, saveStoredSettings, subscribeToSettings } from "./settings";
@@ -29,6 +30,8 @@ export function App({
   const [previewUrls, setPreviewUrls] = useState<Record<string, string>>({});
   const requestedPreviewIds = useRef(new Set<number>());
   const [isDraggingPalette, setIsDraggingPalette] = useState(false);
+  const [isPaletteDragReady, setIsPaletteDragReady] = useState(false);
+  const paletteDragModifierRef = useRef(false);
   const [dragPosition, setDragPosition] = useState<PalettePosition | undefined>();
   const [dragPreviewCell, setDragPreviewCell] = useState<{ column: number; row: number }>();
   const paletteCardRef = useRef<HTMLDivElement>(null);
@@ -288,6 +291,10 @@ export function App({
   // Global keyup/keydown handler for releasing Alt key and cycling in switcher mode
   useMountEffect(() => {
     const handleWindowKeyUp = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Alt") {
+        paletteDragModifierRef.current = false;
+        setIsPaletteDragReady(false);
+      }
       if (modeRef.current !== "switcher") return;
       if (event.key === "Alt" || !event.altKey) {
         const currentTabs = tabsRef.current;
@@ -301,6 +308,10 @@ export function App({
     };
 
     const handleWindowKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Alt") {
+        paletteDragModifierRef.current = true;
+        setIsPaletteDragReady(true);
+      }
       if (event.altKey && (event.key.toLowerCase() === "m" || event.code === "KeyM")) {
         event.preventDefault();
         event.stopPropagation();
@@ -498,12 +509,12 @@ export function App({
   const visiblePalettePosition = dragPosition ?? settings.palettePosition;
 
   const handlePalettePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    const target = event.target instanceof Element ? event.target.closest("input, button") : null;
-    if (
-      settings.disableMouseCommandPalette ||
-      event.button !== 0 ||
-      target !== null
-    ) return;
+    if (!canStartPaletteDrag({
+      altKey: event.altKey || paletteDragModifierRef.current,
+      button: event.button,
+    })) return;
+    event.preventDefault();
+    event.stopPropagation();
     const position = settings.palettePosition;
     paletteDragRef.current = {
       pointerId: event.pointerId,
@@ -523,7 +534,14 @@ export function App({
 
   const handlePalettePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
     const drag = paletteDragRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (!drag) {
+      if (paletteDragModifierRef.current !== event.altKey) {
+        paletteDragModifierRef.current = event.altKey;
+        setIsPaletteDragReady(event.altKey);
+      }
+      return;
+    }
+    if (drag.pointerId !== event.pointerId) return;
     const deltaX = event.clientX - drag.startX;
     const deltaY = event.clientY - drag.startY;
     if (Math.abs(deltaX) > 3 || Math.abs(deltaY) > 3) drag.moved = true;
@@ -592,19 +610,26 @@ export function App({
       )}
       <div
         ref={paletteCardRef}
-        className={`palette-card ${showDropdown ? "is-expanded" : ""} ${isGallery && showDropdown ? "is-gallery-view" : ""} ${isClosing ? "is-closing" : ""} ${isDraggingPalette ? "is-dragging" : ""}`}
+        className={`palette-card ${showDropdown ? "is-expanded" : ""} ${isGallery && showDropdown ? "is-gallery-view" : ""} ${isClosing ? "is-closing" : ""} ${isPaletteDragReady ? "is-drag-ready" : ""} ${isDraggingPalette ? "is-dragging" : ""}`}
         style={{ left: `${visiblePalettePosition.x * 100}%`, top: `${visiblePalettePosition.y * 100}%` }}
         role="dialog"
         aria-modal="true"
+        onPointerDown={handlePalettePointerDown}
+        onPointerMove={handlePalettePointerMove}
+        onPointerUp={finishPaletteDrag}
+        onPointerCancel={cancelPaletteDrag}
+        onPointerEnter={(event) => {
+          paletteDragModifierRef.current = event.altKey;
+          setIsPaletteDragReady(event.altKey);
+        }}
+        onPointerLeave={() => {
+          if (paletteDragRef.current) return;
+          paletteDragModifierRef.current = false;
+          setIsPaletteDragReady(false);
+        }}
       >
         {/* Elevated 3D Search Bar Input Row */}
-        <div
-          className="search-bar-row"
-          onPointerDown={handlePalettePointerDown}
-          onPointerMove={handlePalettePointerMove}
-          onPointerUp={finishPaletteDrag}
-          onPointerCancel={cancelPaletteDrag}
-        >
+        <div className="search-bar-row">
           <SearchIcon size={17} className="search-lead-icon" />
           <input
             ref={inputRef}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { activateTab, getBrowserHistory, getTabs, openUrl, searchWeb, setTabMuted, setTabPinned, type BrowserHistoryItem } from "./browser";
+import { activateTab, getBrowserHistory, getTabPreviews, getTabs, notifyPaletteClosed, notifyPaletteOpened, openUrl, searchWeb, setTabMuted, setTabPinned, type BrowserHistoryItem } from "./browser";
 import { ArrowRightIcon, InfoIcon, PinIcon, SearchIcon, XIcon } from "./icons";
 import { PaletteAction } from "./PaletteAction";
 import { buildSearchResults, type SearchResult } from "./paletteSearch";
@@ -13,12 +13,10 @@ import type { BrowserMessage, PalettePosition, PaletteTab, UserSettings } from "
 export function App({
   onClose,
   initialMode = "search",
-  previewUrl,
   initialActiveTabId,
 }: {
   onClose: () => void;
   initialMode?: "search" | "switcher";
-  previewUrl?: string;
   initialActiveTabId?: number;
 }) {
   const [tabs, setTabs] = useState<PaletteTab[]>([]);
@@ -28,7 +26,8 @@ export function App({
   const [query, setQuery] = useState("");
   const [mode, setMode] = useState<"search" | "switcher">(initialMode);
   const [settings, setSettings] = useState<UserSettings>(DEFAULT_SETTINGS);
-  const [currentPreviewUrl, setCurrentPreviewUrl] = useState(previewUrl);
+  const [previewUrls, setPreviewUrls] = useState<Record<string, string>>({});
+  const requestedPreviewIds = useRef(new Set<number>());
   const [isDraggingPalette, setIsDraggingPalette] = useState(false);
   const [dragPosition, setDragPosition] = useState<PalettePosition | undefined>();
   const [dragPreviewCell, setDragPreviewCell] = useState<{ column: number; row: number }>();
@@ -47,6 +46,7 @@ export function App({
   const [selectedIndex, setSelectedIndex] = useState(isSwitcher ? 1 : 0);
   const initialSwitcherSelectionPending = useRef(isSwitcher && initialActiveTabId !== undefined);
   const [isClosing, setIsClosing] = useState(false);
+  const isClosingRef = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const trackRef = useRef<HTMLDivElement>(null);
@@ -62,6 +62,13 @@ export function App({
   modeRef.current = mode;
   const tabsRequestIdRef = useRef(0);
 
+  useMountEffect(() => {
+    void notifyPaletteOpened().catch(() => undefined);
+    return () => {
+      void notifyPaletteClosed().catch(() => undefined);
+    };
+  });
+
   // Load and subscribe to persistent settings
   useMountEffect(() => {
     void getStoredSettings().then(setSettings);
@@ -72,6 +79,19 @@ export function App({
 
   const historySearchTimerRef = useRef<number | undefined>(undefined);
   const historyRequestIdRef = useRef(0);
+  const requestTabPreviews = useCallback((tabIds: number[]) => {
+    const missingTabIds = tabIds.filter((tabId) => !requestedPreviewIds.current.has(tabId));
+    if (missingTabIds.length === 0) return;
+    missingTabIds.forEach((tabId) => requestedPreviewIds.current.add(tabId));
+    void getTabPreviews(missingTabIds).then((previews) => {
+      if (Object.keys(previews).length > 0) {
+        setPreviewUrls((current) => ({ ...current, ...previews }));
+      }
+    }).catch(() => {
+      missingTabIds.forEach((tabId) => requestedPreviewIds.current.delete(tabId));
+    });
+  }, []);
+
   const handleQueryChange = useCallback((value: string) => {
     const requestId = historyRequestIdRef.current + 1;
     historyRequestIdRef.current = requestId;
@@ -102,6 +122,9 @@ export function App({
   });
 
   const handleClose = useCallback(() => {
+    if (isClosingRef.current) return;
+    isClosingRef.current = true;
+    void notifyPaletteClosed().catch(() => undefined);
     setIsClosing(true);
     setTimeout(() => {
       onClose();
@@ -160,14 +183,10 @@ export function App({
   // Unified message listener for both in-page overlay and new tab page
   useMountEffect(() => {
     const handleMessage = (message: BrowserMessage) => {
-      if (message.type === "update-switcher-preview") {
-        setCurrentPreviewUrl(message.previewUrl);
-      } else if (message.type === "open-palette") {
+      if (isClosingRef.current) return;
+      if (message.type === "open-palette") {
         if (message.mode === "switcher") {
           setMode("switcher");
-          if (message.previewUrl !== undefined) {
-            setCurrentPreviewUrl(message.previewUrl);
-          }
           setIsExpanded(true);
           setSelectedIndex((currentIndex) => {
             const currentTabs = tabsRef.current;
@@ -180,7 +199,6 @@ export function App({
           });
         } else {
           setMode("search");
-          if (message.previewUrl !== undefined) setCurrentPreviewUrl(message.previewUrl);
           setIsExpanded(false);
           handleQueryChange("");
           setTimeout(() => inputRef.current?.focus(), 50);
@@ -350,12 +368,23 @@ export function App({
   selectedIndexRef.current = activeIndex;
 
   useLayoutEffect(() => {
-    if (!isSwitcher || tabs.length === 0) return;
-    const selectedCard = trackRef.current?.querySelector<HTMLElement>(
-      `[data-switcher-index="${activeIndex}"]`,
-    );
-    selectedCard?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
-  }, [activeIndex, isSwitcher, tabs.length]);
+    if (isSwitcher && tabs.length > 0) {
+      const selectedCard = trackRef.current?.querySelector<HTMLElement>(
+        `[data-switcher-index="${activeIndex}"]`,
+      );
+      selectedCard?.scrollIntoView({ behavior: "auto", block: "nearest", inline: "center" });
+      const start = Math.max(0, activeIndex - 3);
+      requestTabPreviews(tabs.slice(start, activeIndex + 5).map((tab) => tab.id));
+      return;
+    }
+
+    if (isGallery) {
+      const start = Math.max(0, activeIndex - 4);
+      requestTabPreviews(results.slice(start, activeIndex + 8).flatMap((result) =>
+        result.kind === "tab" ? [result.tab.id] : []
+      ));
+    }
+  }, [activeIndex, isGallery, isSwitcher, requestTabPreviews, results, tabs]);
 
   const autocompleteFocusedSuggestion = useCallback(() => {
     const result = results[activeIndex];
@@ -427,6 +456,7 @@ export function App({
       <div
         className={`palette-backdrop switcher-backdrop ${isClosing ? "is-closing" : ""}`}
         data-theme={settings.theme}
+        data-vibrancy={settings.useVibrancy ? "on" : "off"}
         onMouseDown={(event) => {
           if (event.target === event.currentTarget) handleClose();
         }}
@@ -448,7 +478,7 @@ export function App({
                   tab={tab}
                   index={index}
                   isSelected={index === activeIndex}
-                  previewUrl={currentPreviewUrl}
+                  previewUrl={previewUrls[String(tab.id)]}
                   onClick={settings.disableMouseTabSwitcher ? undefined : () => void switchTab(tab)}
                   onMouseEnter={settings.disableMouseTabSwitcher ? undefined : () => setSelectedIndex(index)}
                   onToggleMute={settings.disableMouseTabSwitcher ? undefined : () => void muteTab(tab)}
@@ -545,6 +575,7 @@ export function App({
     <div
       className={`palette-backdrop ${isClosing ? "is-closing" : ""}`}
       data-theme={settings.theme}
+      data-vibrancy={settings.useVibrancy ? "on" : "off"}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) handleClose();
       }}
@@ -638,7 +669,7 @@ export function App({
                     tab={result.tab}
                     index={index}
                     isSelected={index === activeIndex}
-                    previewUrl={currentPreviewUrl}
+                    previewUrl={previewUrls[String(result.tab.id)]}
                     onClick={settings.disableMouseCommandPalette ? undefined : () => executeResult(result)}
                     onMouseEnter={settings.disableMouseCommandPalette ? undefined : () => setSelectedIndex(index)}
                     onToggleMute={settings.disableMouseCommandPalette ? undefined : () => void muteTab(result.tab)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -549,60 +549,6 @@ export function App({
 
   const visiblePalettePosition = dragPosition ?? settings.palettePosition;
 
-  if (isBookmarks) {
-    return (
-      <BookmarkManager
-        theme={settings.theme}
-        useVibrancy={settings.useVibrancy}
-        disableMouse={settings.disableMouseCommandPalette}
-        position={visiblePalettePosition}
-        isClosing={isClosing}
-        onClose={handleClose}
-      />
-    );
-  }
-
-  // Visual Horizontal Switcher Mode (Alt + Q)
-  if (isSwitcher) {
-    return (
-      <div
-        className={`palette-backdrop switcher-backdrop ${isClosing ? "is-closing" : ""}`}
-        data-theme={settings.theme}
-        data-vibrancy={settings.useVibrancy ? "on" : "off"}
-        onMouseDown={(event) => {
-          if (event.target === event.currentTarget) handleClose();
-        }}
-      >
-        <div className={`switcher-hud ${isClosing ? "is-closing" : ""}`} role="dialog" aria-label="Tab Switcher">
-          <div
-            className={`switcher-track ${tabs.length <= 3 ? "is-centered" : ""}`}
-            ref={trackRef}
-            role="listbox"
-          >
-            {tabs.length === 0 ? (
-              <div className="empty-state">
-                <span>No open tabs</span>
-              </div>
-            ) : (
-              tabs.map((tab, index) => (
-                <SwitcherCard
-                  key={`switcher-${tab.windowId}-${tab.id}`}
-                  tab={tab}
-                  index={index}
-                  isSelected={index === activeIndex}
-                  previewUrl={previewUrls[String(tab.id)]}
-                  onClick={settings.disableMouseTabSwitcher ? undefined : () => void switchTab(tab)}
-                  onMouseEnter={settings.disableMouseTabSwitcher ? undefined : () => setSelectedIndex(index)}
-                  onToggleMute={settings.disableMouseTabSwitcher ? undefined : () => void muteTab(tab)}
-                />
-              ))
-            )}
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   // Minimal Search Mode (Command + Shift + P)
   // By default, initially only shows the search input bar.
   // Expands only when user types or presses Down arrow.
@@ -788,6 +734,60 @@ export function App({
   const cancelPaletteDrag = (event: React.PointerEvent<HTMLDivElement>) => {
     cancelPaletteDragAt(event.pointerId);
   };
+
+  if (isBookmarks) {
+    return (
+      <BookmarkManager
+        theme={settings.theme}
+        useVibrancy={settings.useVibrancy}
+        disableMouse={settings.disableMouseBookmarks}
+        position={visiblePalettePosition}
+        isClosing={isClosing}
+        onClose={handleClose}
+      />
+    );
+  }
+
+  // Visual Horizontal Switcher Mode (Alt + Q)
+  if (isSwitcher) {
+    return (
+      <div
+        className={`palette-backdrop switcher-backdrop ${isClosing ? "is-closing" : ""}`}
+        data-theme={settings.theme}
+        data-vibrancy={settings.useVibrancy ? "on" : "off"}
+        onMouseDown={(event) => {
+          if (event.target === event.currentTarget) handleClose();
+        }}
+      >
+        <div className={`switcher-hud ${isClosing ? "is-closing" : ""}`} role="dialog" aria-label="Tab Switcher">
+          <div
+            className={`switcher-track ${tabs.length <= 3 ? "is-centered" : ""}`}
+            ref={trackRef}
+            role="listbox"
+          >
+            {tabs.length === 0 ? (
+              <div className="empty-state">
+                <span>No open tabs</span>
+              </div>
+            ) : (
+              tabs.map((tab, index) => (
+                <SwitcherCard
+                  key={`switcher-${tab.windowId}-${tab.id}`}
+                  tab={tab}
+                  index={index}
+                  isSelected={index === activeIndex}
+                  previewUrl={previewUrls[String(tab.id)]}
+                  onClick={settings.disableMouseTabSwitcher ? undefined : () => void switchTab(tab)}
+                  onMouseEnter={settings.disableMouseTabSwitcher ? undefined : () => setSelectedIndex(index)}
+                  onToggleMute={settings.disableMouseTabSwitcher ? undefined : () => void muteTab(tab)}
+                />
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useLayoutEffect, useMemo, useRef, useState, type KeyboardE
 import { activateTab, getBrowserHistory, getTabPreviews, getTabs, notifyPaletteClosed, notifyPaletteOpened, openUrl, searchWeb, setTabMuted, setTabPinned, type BrowserHistoryItem } from "./browser";
 import { ArrowRightIcon, InfoIcon, PinIcon, SearchIcon, XIcon } from "./icons";
 import { PaletteAction } from "./PaletteAction";
-import { canStartPaletteDrag } from "./paletteDrag";
+import { canStartPaletteDrag, dragPreviewCellForPoint, isAltModifierActive, nextFreeDragPosition, snapPalettePosition } from "./paletteDrag";
 import { buildSearchResults, type SearchResult } from "./paletteSearch";
 import { stalePreviewTabIds } from "./previewCache";
 import { getSearchHistory, recordSearch, type SearchHistoryEntry } from "./searchHistory";
@@ -46,6 +46,14 @@ export function App({
     startPosition: PalettePosition;
     moved: boolean;
   } | undefined>(undefined);
+  const pointerDownAnchorRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    button: number;
+  } | undefined>(undefined);
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
 
   const isSwitcher = mode === "switcher";
   const isGallery = settings.viewMode === "gallery";
@@ -352,7 +360,7 @@ export function App({
   // Global keyup/keydown handler for releasing Alt key and cycling in switcher mode
   useMountEffect(() => {
     const handleWindowKeyUp = (event: globalThis.KeyboardEvent) => {
-      if (event.key === "Alt") {
+      if (event.key === "Alt" || !isAltModifierActive(event)) {
         paletteDragModifierRef.current = false;
         setIsPaletteDragReady(false);
       }
@@ -369,9 +377,9 @@ export function App({
     };
 
     const handleWindowKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (event.key === "Alt") {
+      if (isAltModifierActive(event)) {
         paletteDragModifierRef.current = true;
-        setIsPaletteDragReady(true);
+        setIsPaletteDragReady(!settingsRef.current.disableMouseCommandPalette);
       }
       if (event.altKey && (event.key.toLowerCase() === "m" || event.code === "KeyM")) {
         event.preventDefault();
@@ -448,6 +456,18 @@ export function App({
       const start = Math.max(0, activeIndex - 3);
       requestTabPreviews(tabs.slice(start, activeIndex + 5).map((tab) => tab.id));
       return;
+    }
+
+    const selectedItem = listRef.current?.querySelector<HTMLElement>(`[data-index="${activeIndex}"]`);
+    const list = listRef.current;
+    if (selectedItem && list) {
+      const listRect = list.getBoundingClientRect();
+      const itemRect = selectedItem.getBoundingClientRect();
+      if (itemRect.top < listRect.top) {
+        list.scrollTop -= listRect.top - itemRect.top;
+      } else if (itemRect.bottom > listRect.bottom) {
+        list.scrollTop += itemRect.bottom - listRect.bottom;
+      }
     }
 
     if (isGallery) {
@@ -569,73 +589,76 @@ export function App({
   const showDropdown = isExpanded || Boolean(query.trim());
   const visiblePalettePosition = dragPosition ?? settings.palettePosition;
 
-  const handlePalettePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    const target = event.target instanceof Element
-      ? event.target.closest("input, button, select, textarea, a, [role=button], [role=option]")
-      : null;
-    if (target !== null || !canStartPaletteDrag({
-      altKey: event.altKey || paletteDragModifierRef.current,
-      button: event.button,
-      mouseDisabled: settings.disableMouseCommandPalette,
-    })) return;
-    event.preventDefault();
-    event.stopPropagation();
-    const position = settings.palettePosition;
+  const startPaletteDrag = useCallback((clientX: number, clientY: number, pointerId: number, moved = false) => {
+    const position = settingsRef.current.palettePosition;
     paletteDragRef.current = {
-      pointerId: event.pointerId,
-      startX: event.clientX,
-      startY: event.clientY,
+      pointerId,
+      startX: clientX,
+      startY: clientY,
       startPosition: position,
-      moved: false,
+      moved,
     };
     setDragPosition(position);
-    setDragPreviewCell({
-      column: Math.min(2, Math.max(0, Math.floor((event.clientX / window.innerWidth) * 3))),
-      row: Math.min(2, Math.max(0, Math.floor((event.clientY / window.innerHeight) * 3))),
-    });
-    event.currentTarget.setPointerCapture(event.pointerId);
+    setDragPreviewCell(dragPreviewCellForPoint({
+      clientX,
+      clientY,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    }));
     setIsDraggingPalette(true);
-  };
+  }, []);
 
-  const handlePalettePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+  const updatePaletteDrag = useCallback((clientX: number, clientY: number, pointerId: number) => {
     const drag = paletteDragRef.current;
-    if (!drag) {
-      if (paletteDragModifierRef.current !== event.altKey) {
-        paletteDragModifierRef.current = event.altKey;
-        setIsPaletteDragReady(event.altKey);
-      }
-      return;
+    if (!drag || drag.pointerId !== pointerId) return;
+    if (Math.abs(clientX - drag.startX) > 3 || Math.abs(clientY - drag.startY) > 3) drag.moved = true;
+    setDragPosition(nextFreeDragPosition({
+      startX: drag.startX,
+      startY: drag.startY,
+      startPosition: drag.startPosition,
+      clientX,
+      clientY,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    }));
+    setDragPreviewCell(dragPreviewCellForPoint({
+      clientX,
+      clientY,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    }));
+  }, []);
+
+  const releasePalettePointerCapture = useCallback((pointerId: number) => {
+    try {
+      const card = paletteCardRef.current;
+      if (card?.hasPointerCapture?.(pointerId)) card.releasePointerCapture(pointerId);
+    } catch {
+      // Releasing capture is best-effort; window listeners already track the drag.
     }
-    if (drag.pointerId !== event.pointerId) return;
-    const deltaX = event.clientX - drag.startX;
-    const deltaY = event.clientY - drag.startY;
-    if (Math.abs(deltaX) > 3 || Math.abs(deltaY) > 3) drag.moved = true;
-    const nextPosition = {
-      x: Math.min(1, Math.max(0, drag.startPosition.x + deltaX / window.innerWidth)),
-      y: Math.min(1, Math.max(0, drag.startPosition.y + deltaY / window.innerHeight)),
-    };
-    setDragPosition(nextPosition);
-    setDragPreviewCell({
-      column: Math.min(2, Math.max(0, Math.floor((event.clientX / window.innerWidth) * 3))),
-      row: Math.min(2, Math.max(0, Math.floor((event.clientY / window.innerHeight) * 3))),
-    });
-  };
+  }, []);
 
-  const finishPaletteDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+  const finishPaletteDragAt = useCallback((clientX: number, clientY: number, pointerId: number) => {
     const drag = paletteDragRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (!drag || drag.pointerId !== pointerId) return;
     const card = paletteCardRef.current;
-    const column = Math.min(2, Math.max(0, Math.floor((event.clientX / window.innerWidth) * 3)));
-    const row = Math.min(2, Math.max(0, Math.floor((event.clientY / window.innerHeight) * 3)));
     const width = card?.getBoundingClientRect().width ?? 640;
     const height = card?.getBoundingClientRect().height ?? 54;
-    const x = Math.min(1 - width / (window.innerWidth * 2), Math.max(width / (window.innerWidth * 2), (column + 0.5) / 3));
-    const y = Math.min(
-      1 - height / window.innerHeight,
-      Math.max(0, (row + 0.5) / 3 - height / (window.innerHeight * 2)),
-    );
-    const nextPosition = { x, y };
+    const nextPosition = snapPalettePosition({
+      ...dragPreviewCellForPoint({
+        clientX,
+        clientY,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      }),
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      cardWidth: width,
+      cardHeight: height,
+    });
     paletteDragRef.current = undefined;
+    pointerDownAnchorRef.current = undefined;
+    releasePalettePointerCapture(pointerId);
     setIsDraggingPalette(false);
     setDragPosition(undefined);
     setDragPreviewCell(undefined);
@@ -643,15 +666,108 @@ export function App({
       setSettings((current) => ({ ...current, palettePosition: nextPosition }));
       void saveStoredSettings({ palettePosition: nextPosition }).then(setSettings);
     }
-  };
+  }, [releasePalettePointerCapture]);
 
-  const cancelPaletteDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+  const cancelPaletteDragAt = useCallback((pointerId: number) => {
     const drag = paletteDragRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (!drag || drag.pointerId !== pointerId) return;
     paletteDragRef.current = undefined;
+    pointerDownAnchorRef.current = undefined;
+    releasePalettePointerCapture(pointerId);
     setIsDraggingPalette(false);
     setDragPosition(undefined);
     setDragPreviewCell(undefined);
+  }, [releasePalettePointerCapture]);
+
+  // Track the drag at window level so moves keep arriving even when pointer
+  // capture fails or events retarget outside the card (fast drags, native
+  // input behaviors, shadow-DOM retargeting). Also starts the drag when Alt
+  // is pressed mid-press, so both press orders work.
+  useMountEffect(() => {
+    const handleWindowPointerMove = (event: globalThis.PointerEvent) => {
+      if (paletteDragRef.current) {
+        updatePaletteDrag(event.clientX, event.clientY, event.pointerId);
+        return;
+      }
+      const anchor = pointerDownAnchorRef.current;
+      if (!anchor || anchor.pointerId !== event.pointerId) return;
+      if (!(event.buttons & 1) || anchor.button !== 0) return;
+      if (!isAltModifierActive(event) || settingsRef.current.disableMouseCommandPalette) return;
+      if (Math.abs(event.clientX - anchor.startX) <= 3 && Math.abs(event.clientY - anchor.startY) <= 3) return;
+      startPaletteDrag(event.clientX, event.clientY, event.pointerId, true);
+    };
+    const clearAnchorWithoutDrag = (pointerId: number) => {
+      if (pointerDownAnchorRef.current?.pointerId === pointerId && !paletteDragRef.current) {
+        pointerDownAnchorRef.current = undefined;
+      }
+    };
+    const handleWindowPointerUp = (event: globalThis.PointerEvent) => {
+      clearAnchorWithoutDrag(event.pointerId);
+      finishPaletteDragAt(event.clientX, event.clientY, event.pointerId);
+    };
+    const handleWindowPointerCancel = (event: globalThis.PointerEvent) => {
+      clearAnchorWithoutDrag(event.pointerId);
+      cancelPaletteDragAt(event.pointerId);
+    };
+    const handleWindowBlur = () => {
+      const drag = paletteDragRef.current;
+      paletteDragModifierRef.current = false;
+      setIsPaletteDragReady(false);
+      if (drag) cancelPaletteDragAt(drag.pointerId);
+    };
+    window.addEventListener("pointermove", handleWindowPointerMove);
+    window.addEventListener("pointerup", handleWindowPointerUp);
+    window.addEventListener("pointercancel", handleWindowPointerCancel);
+    window.addEventListener("blur", handleWindowBlur);
+    return () => {
+      window.removeEventListener("pointermove", handleWindowPointerMove);
+      window.removeEventListener("pointerup", handleWindowPointerUp);
+      window.removeEventListener("pointercancel", handleWindowPointerCancel);
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  });
+
+  const handlePalettePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button === 0) {
+      pointerDownAnchorRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        button: event.button,
+      };
+    }
+    if (!canStartPaletteDrag({
+      altKey: isAltModifierActive(event) || paletteDragModifierRef.current,
+      button: event.button,
+      mouseDisabled: settingsRef.current.disableMouseCommandPalette,
+    })) return;
+    event.preventDefault();
+    startPaletteDrag(event.clientX, event.clientY, event.pointerId);
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // Pointer capture is best-effort; window-level listeners keep tracking the drag.
+    }
+  };
+
+  const handlePalettePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (paletteDragRef.current) {
+      updatePaletteDrag(event.clientX, event.clientY, event.pointerId);
+      return;
+    }
+    const altActive = isAltModifierActive(event);
+    if (paletteDragModifierRef.current !== altActive) {
+      paletteDragModifierRef.current = altActive;
+      setIsPaletteDragReady(altActive && !settingsRef.current.disableMouseCommandPalette);
+    }
+  };
+
+  const finishPaletteDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+    finishPaletteDragAt(event.clientX, event.clientY, event.pointerId);
+  };
+
+  const cancelPaletteDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+    cancelPaletteDragAt(event.pointerId);
   };
 
   return (
@@ -660,6 +776,7 @@ export function App({
       data-theme={settings.theme}
       data-vibrancy={settings.useVibrancy ? "on" : "off"}
       onMouseDown={(event) => {
+        if (event.altKey) return;
         if (event.target === event.currentTarget) handleClose();
       }}
     >
@@ -679,13 +796,22 @@ export function App({
         style={{ left: `${visiblePalettePosition.x * 100}%`, top: `${visiblePalettePosition.y * 100}%` }}
         role="dialog"
         aria-modal="true"
-        onPointerDown={handlePalettePointerDown}
-        onPointerMove={handlePalettePointerMove}
-        onPointerUp={finishPaletteDrag}
-        onPointerCancel={cancelPaletteDrag}
+        onPointerDownCapture={handlePalettePointerDown}
+        onPointerMoveCapture={handlePalettePointerMove}
+        onPointerUpCapture={finishPaletteDrag}
+        onPointerCancelCapture={cancelPaletteDrag}
+        onClickCapture={(event) => {
+          // Alt+click is a drag gesture, never an activation: block buttons,
+          // clear/expand toggles, and rows from firing while Alt is held.
+          if (isAltModifierActive(event) || paletteDragModifierRef.current) {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+        }}
         onPointerEnter={(event) => {
-          paletteDragModifierRef.current = event.altKey;
-          setIsPaletteDragReady(event.altKey);
+          const altActive = isAltModifierActive(event);
+          paletteDragModifierRef.current = altActive;
+          setIsPaletteDragReady(altActive && !settingsRef.current.disableMouseCommandPalette);
         }}
         onPointerLeave={() => {
           if (paletteDragRef.current) return;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_SETTINGS, getStoredSettings, pinnedTabIdentity, saveStoredSetti
 import { useMountEffect } from "./hooks/useMountEffect";
 import { TabFavicon, TabSoundIndicator } from "./components/TabVisuals";
 import { GalleryCard, SwitcherCard } from "./components/TabCards";
+import { BookmarkManager } from "./components/BookmarkManager";
 import type { BrowserMessage, PalettePosition, PaletteTab, UserSettings } from "./types";
 
 export function App({
@@ -18,7 +19,7 @@ export function App({
   initialActiveTabId,
 }: {
   onClose: () => void;
-  initialMode?: "search" | "switcher";
+  initialMode?: "search" | "switcher" | "bookmarks";
   initialActiveTabId?: number;
 }) {
   const [tabs, setTabs] = useState<PaletteTab[]>([]);
@@ -26,7 +27,7 @@ export function App({
   const [recentBrowserHistory, setRecentBrowserHistory] = useState<BrowserHistoryItem[]>([]);
   const [browserHistory, setBrowserHistory] = useState<BrowserHistoryItem[]>([]);
   const [query, setQuery] = useState("");
-  const [mode, setMode] = useState<"search" | "switcher">(initialMode);
+  const [mode, setMode] = useState<"search" | "switcher" | "bookmarks">(initialMode);
   const [settings, setSettings] = useState<UserSettings>(DEFAULT_SETTINGS);
   const [previewUrls, setPreviewUrls] = useState<Record<string, string>>({});
   const requestedPreviewIds = useRef(new Set<number>());
@@ -56,6 +57,7 @@ export function App({
   settingsRef.current = settings;
 
   const isSwitcher = mode === "switcher";
+  const isBookmarks = mode === "bookmarks";
   const isGallery = settings.viewMode === "gallery";
   const [isExpanded, setIsExpanded] = useState(isSwitcher);
   const [selectedIndex, setSelectedIndex] = useState(isSwitcher ? 1 : 0);
@@ -257,7 +259,10 @@ export function App({
     const handleMessage = (message: BrowserMessage) => {
       if (isClosingRef.current) return;
       if (message.type === "open-palette") {
-        if (message.mode === "switcher") {
+        if (message.mode === "bookmarks") {
+          setMode("bookmarks");
+          setIsExpanded(false);
+        } else if (message.mode === "switcher") {
           setMode("switcher");
           setIsExpanded(true);
           setSelectedIndex((currentIndex) => {
@@ -542,6 +547,21 @@ export function App({
     }
   }
 
+  const visiblePalettePosition = dragPosition ?? settings.palettePosition;
+
+  if (isBookmarks) {
+    return (
+      <BookmarkManager
+        theme={settings.theme}
+        useVibrancy={settings.useVibrancy}
+        disableMouse={settings.disableMouseCommandPalette}
+        position={visiblePalettePosition}
+        isClosing={isClosing}
+        onClose={handleClose}
+      />
+    );
+  }
+
   // Visual Horizontal Switcher Mode (Alt + Q)
   if (isSwitcher) {
     return (
@@ -587,7 +607,6 @@ export function App({
   // By default, initially only shows the search input bar.
   // Expands only when user types or presses Down arrow.
   const showDropdown = isExpanded || Boolean(query.trim());
-  const visiblePalettePosition = dragPosition ?? settings.palettePosition;
 
   const startPaletteDrag = useCallback((clientX: number, clientY: number, pointerId: number, moved = false) => {
     const position = settingsRef.current.palettePosition;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -570,9 +570,13 @@ export function App({
   const visiblePalettePosition = dragPosition ?? settings.palettePosition;
 
   const handlePalettePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
-    if (!canStartPaletteDrag({
+    const target = event.target instanceof Element
+      ? event.target.closest("input, button, select, textarea, a, [role=button], [role=option]")
+      : null;
+    if (target !== null || !canStartPaletteDrag({
       altKey: event.altKey || paletteDragModifierRef.current,
       button: event.button,
+      mouseDisabled: settings.disableMouseCommandPalette,
     })) return;
     event.preventDefault();
     event.stopPropagation();

--- a/src/background.ts
+++ b/src/background.ts
@@ -3,11 +3,12 @@ import { getStoredSettings, pinnedTabIdentity, saveStoredSettings } from "./sett
 import type { BrowserMessage, PaletteTab } from "./types";
 
 const LEGACY_PREVIEW_CACHE_KEY = "recent-tab-previews";
-const PREVIEW_CACHE_PREFIX = "tab-preview:";
-const PREVIEW_CAPTURE_DELAY_MS = 600;
+const LEGACY_PREVIEW_CACHE_PREFIX = "tab-preview:";
+const PREVIEW_CACHE_PREFIX = "tab-preview-v2:";
+const PREVIEW_CAPTURE_DELAY_MS = 250;
 const PREVIEW_CAPTURE_INTERVAL_MS = 550;
-const PREVIEW_MAX_WIDTH = 480;
-const PREVIEW_MAX_HEIGHT = 300;
+const PREVIEW_MAX_WIDTH = 640;
+const PREVIEW_MAX_HEIGHT = 400;
 const HISTORY_CACHE_LIMIT = 100;
 
 type HistoryResult = {
@@ -32,6 +33,7 @@ function enqueuePinUpdate(update: () => Promise<void>) {
 }
 
 const previewCache = new Map<number, PreviewEntry>();
+const overlayTabIds = new Set<number>();
 const previewCaptureTimers = new Map<number, { tabId: number; timer: ReturnType<typeof setTimeout> }>();
 let previewCaptureQueue = Promise.resolve();
 let lastPreviewCaptureStartedAt = 0;
@@ -72,8 +74,8 @@ async function compactPreview(dataUrl: string) {
     }
     context.drawImage(source, 0, 0, width, height);
     source.close();
-    const blob = await canvas.convertToBlob({ type: "image/jpeg", quality: 0.55 });
-    return `data:image/jpeg;base64,${bytesToBase64(new Uint8Array(await blob.arrayBuffer()))}`;
+    const blob = await canvas.convertToBlob({ type: "image/webp", quality: 0.82 });
+    return `data:image/webp;base64,${bytesToBase64(new Uint8Array(await blob.arrayBuffer()))}`;
   } catch {
     return dataUrl;
   }
@@ -90,21 +92,18 @@ async function persistPreview(entry: PreviewEntry) {
 const previewCacheReady = chrome.storage.session
   .get(null)
   .then(async (stored) => {
-    const legacyEntries = parsePreviewEntries(stored[LEGACY_PREVIEW_CACHE_KEY]);
     const keyedEntries = Object.entries(stored).flatMap(([key, value]) =>
       key.startsWith(PREVIEW_CACHE_PREFIX) ? parsePreviewEntries([value]) : []
     );
-    [...legacyEntries, ...keyedEntries].forEach((entry) => previewCache.set(entry.tabId, entry));
+    keyedEntries.forEach((entry) => previewCache.set(entry.tabId, entry));
 
-    const keyedTabIds = new Set(keyedEntries.map((entry) => entry.tabId));
-    const entriesToMigrate = legacyEntries.filter((entry) => !keyedTabIds.has(entry.tabId));
-    if (legacyEntries.length > 0) {
-      if (entriesToMigrate.length > 0) {
-        await chrome.storage.session.set(Object.fromEntries(
-          entriesToMigrate.map((entry) => [previewStorageKey(entry.tabId), entry]),
-        ));
-      }
-      await chrome.storage.session.remove(LEGACY_PREVIEW_CACHE_KEY);
+    // Version 1 previews may contain the palette itself and used a much lower
+    // quality encode. Drop them instead of carrying bad images forward.
+    const obsoletePreviewKeys = Object.keys(stored).filter((key) =>
+      key === LEGACY_PREVIEW_CACHE_KEY || key.startsWith(LEGACY_PREVIEW_CACHE_PREFIX)
+    );
+    if (obsoletePreviewKeys.length > 0) {
+      await chrome.storage.session.remove(obsoletePreviewKeys);
     }
   })
   .catch(() => {});
@@ -120,23 +119,30 @@ async function capturePreview(tabId: number, windowId: number) {
 
   try {
     const tab = await chrome.tabs.get(tabId);
-    if (!tab.active || tab.discarded || !tab.url) return;
+    if (overlayTabIds.has(tabId) || !tab.active || tab.discarded || !tab.url) return;
 
-    const capturedDataUrl = await chrome.tabs.captureVisibleTab(windowId, {
-      format: "jpeg",
-      quality: 45,
-    });
+    const capturedDataUrl = await chrome.tabs.captureVisibleTab(windowId, { format: "png" });
     const currentTab = await chrome.tabs.get(tabId);
-    if (!capturedDataUrl || currentTab.url !== tab.url || !currentTab.active) return;
+    if (overlayTabIds.has(tabId) || !capturedDataUrl || currentTab.url !== tab.url || !currentTab.active) return;
 
+    const capturedAt = Date.now();
     const entry = {
       tabId,
       url: tab.url,
-      dataUrl: await compactPreview(capturedDataUrl),
-      capturedAt: Date.now(),
+      dataUrl: capturedDataUrl,
+      capturedAt,
     };
     previewCache.set(tabId, entry);
-    await persistPreview(entry);
+
+    // Make the raw preview available immediately. Compression and storage are
+    // background work so they cannot delay the switcher or its repeat rate.
+    void compactPreview(capturedDataUrl).then(async (dataUrl) => {
+      const currentEntry = previewCache.get(tabId);
+      if (currentEntry?.capturedAt !== capturedAt || currentEntry.url !== tab.url) return;
+      const compactedEntry = { ...entry, dataUrl };
+      previewCache.set(tabId, compactedEntry);
+      await persistPreview(compactedEntry);
+    }).catch(() => undefined);
   } catch {
     // Restricted browser pages and closed tabs cannot be captured.
   }
@@ -172,12 +178,14 @@ async function scheduleActiveTabCaptures() {
 }
 
 async function sendToTab(tab: chrome.tabs.Tab, message: BrowserMessage) {
-  if (tab.id === undefined) return;
+  if (tab.id === undefined) return false;
   try {
     await chrome.tabs.sendMessage(tab.id, message);
+    return true;
   } catch {
     // Content scripts run declaratively on regular web pages. Browser-owned
     // pages and tabs opened before an extension reload cannot host the palette.
+    return false;
   }
 }
 
@@ -270,7 +278,6 @@ async function getTabs(): Promise<PaletteTab[]> {
 
   return browserTabs
     .map((tab) => {
-      const preview = previewCache.get(tab.id);
       return {
         id: tab.id,
         windowId: tab.windowId,
@@ -279,7 +286,6 @@ async function getTabs(): Promise<PaletteTab[]> {
         hostname: hostnameFor(tab.url),
         index: tab.index,
         faviconUrl: tab.favIconUrl,
-        previewUrl: preview && preview.url === tab.url ? preview.dataUrl : undefined,
         active: Boolean(tab.active),
         windowFocused: focusedWindows.has(tab.windowId),
         pinned: pinnedTabs.some((pinnedTab) => {
@@ -312,6 +318,7 @@ chrome.tabs.onActivated.addListener(({ tabId, windowId }) => {
 });
 
 chrome.tabs.onRemoved.addListener((tabId, { windowId }) => {
+  overlayTabIds.delete(tabId);
   const pendingCapture = previewCaptureTimers.get(windowId);
   if (pendingCapture?.tabId === tabId) {
     clearTimeout(pendingCapture.timer);
@@ -321,7 +328,10 @@ chrome.tabs.onRemoved.addListener((tabId, { windowId }) => {
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.url !== undefined) void removeCachedPreview(tabId);
+  if (changeInfo.url !== undefined) {
+    overlayTabIds.delete(tabId);
+    void removeCachedPreview(tabId);
+  }
   if (tab.active && (changeInfo.status === "complete" || changeInfo.url !== undefined)) {
     schedulePreviewCapture(tabId, tab.windowId);
   }
@@ -340,36 +350,43 @@ async function openSearchPalette() {
 
   // Search mode does not need a fresh screenshot. Open it immediately and let
   // the switcher own screenshot capture, so the command never feels delayed.
-  await sendToTab(tab, { type: "open-palette", mode: "search" });
+  if (tab.id !== undefined) overlayTabIds.add(tab.id);
+  const opened = await sendToTab(tab, { type: "open-palette", mode: "search" });
+  if (!opened && tab.id !== undefined) overlayTabIds.delete(tab.id);
 }
 
+let switcherOpenInFlight = false;
+
 async function openTabSwitcher() {
-  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-  if (!tab) return;
+  if (switcherOpenInFlight) return;
+  switcherOpenInFlight = true;
 
-  // Active tabs are captured as they settle. Only block the first switcher open
-  // when no preview exists; cached opens remain instantaneous and never capture
-  // the switcher UI itself.
-  if (tab.id !== undefined && !previewCache.has(tab.id)) {
-    const pendingCapture = previewCaptureTimers.get(tab.windowId);
-    if (pendingCapture !== undefined) clearTimeout(pendingCapture.timer);
-    previewCaptureTimers.delete(tab.windowId);
-    await enqueuePreviewCapture(tab.id, tab.windowId);
-  }
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+    if (!tab) return;
 
-  const [currentTab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
-  const preview = tab.id !== undefined ? previewCache.get(tab.id) : undefined;
-  const previewUrl = currentTab?.id === tab.id && currentTab.url === preview?.url
-    ? preview?.dataUrl
-    : undefined;
+    // Capture only when the active tab has no valid cached preview. The raw
+    // frame is available before compression, and overlapping shortcut events
+    // are dropped instead of queued for delivery after Alt is released.
+    await previewCacheReady;
+    const cachedPreview = tab.id !== undefined ? previewCache.get(tab.id) : undefined;
+    const canCaptureNow = Date.now() - lastPreviewCaptureStartedAt >= PREVIEW_CAPTURE_INTERVAL_MS;
+    if (tab.id !== undefined && cachedPreview?.url !== tab.url && canCaptureNow) {
+      lastPreviewCaptureStartedAt = Date.now();
+      await capturePreview(tab.id, tab.windowId);
+    }
 
-  if (currentTab) {
-    await sendToTab(currentTab, {
+    // getTabs supplies every cached preview in one response after mount. Keep
+    // this command message small instead of sending the active image twice.
+    if (tab.id !== undefined) overlayTabIds.add(tab.id);
+    const opened = await sendToTab(tab, {
       type: "open-palette",
       mode: "switcher",
-      previewUrl,
-      activeTabId: currentTab.id,
+      activeTabId: tab.id,
     });
+    if (!opened && tab.id !== undefined) overlayTabIds.delete(tab.id);
+  } finally {
+    switcherOpenInFlight = false;
   }
 }
 
@@ -382,9 +399,32 @@ chrome.commands.onCommand.addListener((command) => {
 
 chrome.action.onClicked.addListener(() => void openSearchPalette());
 
-chrome.runtime.onMessage.addListener((message: BrowserMessage, _sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message: BrowserMessage, sender, sendResponse) => {
+  if (message.type === "palette-opened") {
+    if (sender.tab?.id !== undefined) overlayTabIds.add(sender.tab.id);
+    return false;
+  }
+
+  if (message.type === "palette-closed") {
+    if (sender.tab?.id !== undefined) overlayTabIds.delete(sender.tab.id);
+    return false;
+  }
+
   if (message.type === "get-tabs") {
     void getTabs().then(sendResponse);
+    return true;
+  }
+
+  if (message.type === "get-tab-previews") {
+    const tabIds = message.tabIds
+      .filter((tabId) => Number.isInteger(tabId) && tabId > 0)
+      .slice(0, 12);
+    void previewCacheReady.then(() => {
+      sendResponse(Object.fromEntries(tabIds.flatMap((tabId) => {
+        const preview = previewCache.get(tabId);
+        return preview ? [[String(tabId), preview.dataUrl]] : [];
+      })));
+    });
     return true;
   }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -35,7 +35,9 @@ function enqueuePinUpdate(update: () => Promise<void>) {
 const previewCache = new Map<number, PreviewEntry>();
 const overlayTabIds = new Set<number>();
 const previewCaptureTimers = new Map<number, { tabId: number; timer: ReturnType<typeof setTimeout> }>();
-let previewCaptureQueue = Promise.resolve();
+const pendingPreviewCaptures = new Map<number, { tabId: number; generation: number }>();
+let previewCapturePump: Promise<void> | undefined;
+let previewCaptureGeneration = 0;
 let lastPreviewCaptureStartedAt = 0;
 
 function hostnameFor(url?: string) {
@@ -70,14 +72,14 @@ async function compactPreview(dataUrl: string) {
     const context = canvas.getContext("2d", { alpha: false });
     if (!context) {
       source.close();
-      return dataUrl;
+      return null;
     }
     context.drawImage(source, 0, 0, width, height);
     source.close();
     const blob = await canvas.convertToBlob({ type: "image/webp", quality: 0.82 });
     return `data:image/webp;base64,${bytesToBase64(new Uint8Array(await blob.arrayBuffer()))}`;
   } catch {
-    return dataUrl;
+    return null;
   }
 }
 
@@ -119,11 +121,11 @@ async function capturePreview(tabId: number, windowId: number) {
 
   try {
     const tab = await chrome.tabs.get(tabId);
-    if (overlayTabIds.has(tabId) || !tab.active || tab.discarded || !tab.url) return;
+    if (overlayTabIds.has(tabId) || !tab.active || tab.discarded || !tab.url) return null;
 
     const capturedDataUrl = await chrome.tabs.captureVisibleTab(windowId, { format: "png" });
     const currentTab = await chrome.tabs.get(tabId);
-    if (overlayTabIds.has(tabId) || !capturedDataUrl || currentTab.url !== tab.url || !currentTab.active) return;
+    if (overlayTabIds.has(tabId) || !capturedDataUrl || currentTab.url !== tab.url || !currentTab.active) return null;
 
     const capturedAt = Date.now();
     const entry = {
@@ -137,26 +139,49 @@ async function capturePreview(tabId: number, windowId: number) {
     // Make the raw preview available immediately. Compression and storage are
     // background work so they cannot delay the switcher or its repeat rate.
     void compactPreview(capturedDataUrl).then(async (dataUrl) => {
+      if (dataUrl === null) return;
       const currentEntry = previewCache.get(tabId);
       if (currentEntry?.capturedAt !== capturedAt || currentEntry.url !== tab.url) return;
       const compactedEntry = { ...entry, dataUrl };
       previewCache.set(tabId, compactedEntry);
       await persistPreview(compactedEntry);
     }).catch(() => undefined);
+    return entry;
   } catch {
     // Restricted browser pages and closed tabs cannot be captured.
+    return null;
   }
 }
 
-function enqueuePreviewCapture(tabId: number, windowId: number) {
-  const operation = previewCaptureQueue.catch(() => undefined).then(async () => {
+async function pumpPreviewCaptures() {
+  while (pendingPreviewCaptures.size > 0) {
+    const next = pendingPreviewCaptures.entries().next();
+    if (next.done) break;
+    const [windowId, request] = next.value;
     const waitMs = Math.max(0, PREVIEW_CAPTURE_INTERVAL_MS - (Date.now() - lastPreviewCaptureStartedAt));
     if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, waitMs));
+
+    const latest = pendingPreviewCaptures.get(windowId);
+    if (!latest || latest.generation !== request.generation) continue;
+    pendingPreviewCaptures.delete(windowId);
     lastPreviewCaptureStartedAt = Date.now();
-    await capturePreview(tabId, windowId);
+    await capturePreview(request.tabId, windowId);
+  }
+}
+
+function startPreviewCapturePump() {
+  if (previewCapturePump !== undefined) return;
+  previewCapturePump = pumpPreviewCaptures().finally(() => {
+    previewCapturePump = undefined;
+    startPreviewCapturePump();
   });
-  previewCaptureQueue = operation.catch(() => undefined);
-  return operation;
+}
+
+function enqueuePreviewCapture(tabId: number, windowId: number) {
+  previewCaptureGeneration += 1;
+  pendingPreviewCaptures.set(windowId, { tabId, generation: previewCaptureGeneration });
+  startPreviewCapturePump();
+  return previewCapturePump;
 }
 
 function schedulePreviewCapture(tabId: number, windowId: number) {
@@ -328,7 +353,7 @@ chrome.tabs.onRemoved.addListener((tabId, { windowId }) => {
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.url !== undefined) {
+  if (changeInfo.status === "loading" || changeInfo.url !== undefined) {
     overlayTabIds.delete(tabId);
     void removeCachedPreview(tabId);
   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,17 +1,13 @@
+import { parsePreviewEntries, retainOpenTabPreviews, type PreviewEntry } from "./previewCache";
 import { getStoredSettings, pinnedTabIdentity, saveStoredSettings } from "./settings";
 import type { BrowserMessage, PaletteTab } from "./types";
 
-type PreviewEntry = {
-  tabId: number;
-  url: string;
-  dataUrl: string;
-  capturedAt: number;
-};
-
-const PREVIEW_CACHE_KEY = "recent-tab-previews";
-const PREVIEW_TTL_MS = 24 * 60 * 60 * 1000;
-const MAX_PREVIEW_COUNT = 24;
-const MAX_PREVIEW_CHARACTERS = 9_000_000;
+const LEGACY_PREVIEW_CACHE_KEY = "recent-tab-previews";
+const PREVIEW_CACHE_PREFIX = "tab-preview:";
+const PREVIEW_CAPTURE_DELAY_MS = 600;
+const PREVIEW_CAPTURE_INTERVAL_MS = 550;
+const PREVIEW_MAX_WIDTH = 480;
+const PREVIEW_MAX_HEIGHT = 300;
 const HISTORY_CACHE_LIMIT = 100;
 
 type HistoryResult = {
@@ -36,6 +32,9 @@ function enqueuePinUpdate(update: () => Promise<void>) {
 }
 
 const previewCache = new Map<number, PreviewEntry>();
+const previewCaptureTimers = new Map<number, { tabId: number; timer: ReturnType<typeof setTimeout> }>();
+let previewCaptureQueue = Promise.resolve();
+let lastPreviewCaptureStartedAt = 0;
 
 function hostnameFor(url?: string) {
   if (!url) return "";
@@ -46,106 +45,130 @@ function hostnameFor(url?: string) {
   }
 }
 
-function parsePreviewEntries(value: unknown) {
-  if (!Array.isArray(value)) return [];
-
-  return value.filter((entry): entry is PreviewEntry =>
-    typeof entry === "object" &&
-    entry !== null &&
-    "tabId" in entry &&
-    typeof entry.tabId === "number" &&
-    "url" in entry &&
-    typeof entry.url === "string" &&
-    "dataUrl" in entry &&
-    typeof entry.dataUrl === "string" &&
-    "capturedAt" in entry &&
-    typeof entry.capturedAt === "number"
-  );
+function previewStorageKey(tabId: number) {
+  return `${PREVIEW_CACHE_PREFIX}${tabId}`;
 }
 
-function prunePreviewCache(now = Date.now()) {
-  const previousTabIds = new Set(previewCache.keys());
-  const recentEntries = [...previewCache.values()]
-    .filter((entry) => now - entry.capturedAt < PREVIEW_TTL_MS)
-    .sort((a, b) => b.capturedAt - a.capturedAt);
-
-  previewCache.clear();
-  let totalCharacters = 0;
-
-  for (const entry of recentEntries) {
-    if (previewCache.size >= MAX_PREVIEW_COUNT) break;
-    if (totalCharacters + entry.dataUrl.length > MAX_PREVIEW_CHARACTERS) continue;
-    previewCache.set(entry.tabId, entry);
-    totalCharacters += entry.dataUrl.length;
+function bytesToBase64(bytes: Uint8Array) {
+  let binary = "";
+  const chunkSize = 32_768;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
   }
-
-  return previousTabIds.size !== previewCache.size ||
-    [...previousTabIds].some((tabId) => !previewCache.has(tabId));
+  return btoa(binary);
 }
 
-async function writePreviewCache() {
+async function compactPreview(dataUrl: string) {
   try {
-    await chrome.storage.session.set({
-      [PREVIEW_CACHE_KEY]: [...previewCache.values()],
-    });
+    const source = await createImageBitmap(await (await fetch(dataUrl)).blob());
+    const scale = Math.min(1, PREVIEW_MAX_WIDTH / source.width, PREVIEW_MAX_HEIGHT / source.height);
+    const width = Math.max(1, Math.round(source.width * scale));
+    const height = Math.max(1, Math.round(source.height * scale));
+    const canvas = new OffscreenCanvas(width, height);
+    const context = canvas.getContext("2d", { alpha: false });
+    if (!context) {
+      source.close();
+      return dataUrl;
+    }
+    context.drawImage(source, 0, 0, width, height);
+    source.close();
+    const blob = await canvas.convertToBlob({ type: "image/jpeg", quality: 0.55 });
+    return `data:image/jpeg;base64,${bytesToBase64(new Uint8Array(await blob.arrayBuffer()))}`;
+  } catch {
+    return dataUrl;
+  }
+}
+
+async function persistPreview(entry: PreviewEntry) {
+  try {
+    await chrome.storage.session.set({ [previewStorageKey(entry.tabId)]: entry });
   } catch {
     // The in-memory cache remains usable if session storage is unavailable.
   }
 }
 
-async function persistPreviewCache() {
-  await previewCacheReady;
-  prunePreviewCache();
-  await writePreviewCache();
-}
-
 const previewCacheReady = chrome.storage.session
-  .get(PREVIEW_CACHE_KEY)
+  .get(null)
   .then(async (stored) => {
-    const entries = parsePreviewEntries(stored[PREVIEW_CACHE_KEY]);
-    entries.forEach((entry) => previewCache.set(entry.tabId, entry));
-    if (prunePreviewCache()) await writePreviewCache();
+    const legacyEntries = parsePreviewEntries(stored[LEGACY_PREVIEW_CACHE_KEY]);
+    const keyedEntries = Object.entries(stored).flatMap(([key, value]) =>
+      key.startsWith(PREVIEW_CACHE_PREFIX) ? parsePreviewEntries([value]) : []
+    );
+    [...legacyEntries, ...keyedEntries].forEach((entry) => previewCache.set(entry.tabId, entry));
+
+    const keyedTabIds = new Set(keyedEntries.map((entry) => entry.tabId));
+    const entriesToMigrate = legacyEntries.filter((entry) => !keyedTabIds.has(entry.tabId));
+    if (legacyEntries.length > 0) {
+      if (entriesToMigrate.length > 0) {
+        await chrome.storage.session.set(Object.fromEntries(
+          entriesToMigrate.map((entry) => [previewStorageKey(entry.tabId), entry]),
+        ));
+      }
+      await chrome.storage.session.remove(LEGACY_PREVIEW_CACHE_KEY);
+    }
   })
   .catch(() => {});
 
 async function removeCachedPreview(tabId: number) {
   await previewCacheReady;
   previewCache.delete(tabId);
-  await persistPreviewCache();
+  await chrome.storage.session.remove(previewStorageKey(tabId)).catch(() => undefined);
 }
 
 async function capturePreview(tabId: number, windowId: number) {
   await previewCacheReady;
 
   try {
-    const [tab, window] = await Promise.all([
-      chrome.tabs.get(tabId),
-      chrome.windows.get(windowId),
-    ]);
-    if (!tab.active || !window.focused || !tab.url) return;
+    const tab = await chrome.tabs.get(tabId);
+    if (!tab.active || tab.discarded || !tab.url) return;
 
-    const dataUrl = await chrome.tabs.captureVisibleTab(windowId, {
+    const capturedDataUrl = await chrome.tabs.captureVisibleTab(windowId, {
       format: "jpeg",
-      quality: 35,
+      quality: 45,
     });
     const currentTab = await chrome.tabs.get(tabId);
-    const currentWindow = await chrome.windows.get(windowId);
-    if (!dataUrl || currentTab.url !== tab.url || !currentTab.active || !currentWindow.focused) {
-      previewCache.delete(tabId);
-      await persistPreviewCache();
-      return;
-    }
+    if (!capturedDataUrl || currentTab.url !== tab.url || !currentTab.active) return;
 
-    previewCache.set(tabId, {
+    const entry = {
       tabId,
-      url: currentTab.url ?? tab.url,
-      dataUrl,
+      url: tab.url,
+      dataUrl: await compactPreview(capturedDataUrl),
       capturedAt: Date.now(),
-    });
-    await persistPreviewCache();
+    };
+    previewCache.set(tabId, entry);
+    await persistPreview(entry);
   } catch {
     // Restricted browser pages and closed tabs cannot be captured.
   }
+}
+
+function enqueuePreviewCapture(tabId: number, windowId: number) {
+  const operation = previewCaptureQueue.catch(() => undefined).then(async () => {
+    const waitMs = Math.max(0, PREVIEW_CAPTURE_INTERVAL_MS - (Date.now() - lastPreviewCaptureStartedAt));
+    if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, waitMs));
+    lastPreviewCaptureStartedAt = Date.now();
+    await capturePreview(tabId, windowId);
+  });
+  previewCaptureQueue = operation.catch(() => undefined);
+  return operation;
+}
+
+function schedulePreviewCapture(tabId: number, windowId: number) {
+  const pendingCapture = previewCaptureTimers.get(windowId);
+  if (pendingCapture !== undefined) clearTimeout(pendingCapture.timer);
+
+  const timer = setTimeout(() => {
+    previewCaptureTimers.delete(windowId);
+    void enqueuePreviewCapture(tabId, windowId);
+  }, PREVIEW_CAPTURE_DELAY_MS);
+  previewCaptureTimers.set(windowId, { tabId, timer });
+}
+
+async function scheduleActiveTabCaptures() {
+  const activeTabs = await chrome.tabs.query({ active: true });
+  activeTabs.forEach((tab) => {
+    if (tab.id !== undefined) schedulePreviewCapture(tab.id, tab.windowId);
+  });
 }
 
 async function sendToTab(tab: chrome.tabs.Tab, message: BrowserMessage) {
@@ -235,7 +258,13 @@ async function getTabs(): Promise<PaletteTab[]> {
       await saveStoredSettings({ pinnedTabs: migratedTabs });
     });
   }
-  if (prunePreviewCache()) await writePreviewCache();
+  const retainedPreviews = retainOpenTabPreviews(previewCache.values(), browserTabs);
+  const retainedTabIds = new Set(retainedPreviews.map((entry) => entry.tabId));
+  const staleTabIds = [...previewCache.keys()].filter((tabId) => !retainedTabIds.has(tabId));
+  staleTabIds.forEach((tabId) => previewCache.delete(tabId));
+  if (staleTabIds.length > 0) {
+    void chrome.storage.session.remove(staleTabIds.map(previewStorageKey)).catch(() => undefined);
+  }
 
   const focusedWindows = new Set(windows.filter((window) => window.focused).map((window) => window.id));
 
@@ -275,12 +304,34 @@ async function getTabs(): Promise<PaletteTab[]> {
 chrome.history.onVisited.addListener(invalidateHistoryCache);
 chrome.history.onVisitRemoved.addListener(invalidateHistoryCache);
 
-chrome.tabs.onRemoved.addListener((tabId) => {
+chrome.runtime.onInstalled.addListener(() => void scheduleActiveTabCaptures());
+chrome.runtime.onStartup.addListener(() => void scheduleActiveTabCaptures());
+
+chrome.tabs.onActivated.addListener(({ tabId, windowId }) => {
+  schedulePreviewCapture(tabId, windowId);
+});
+
+chrome.tabs.onRemoved.addListener((tabId, { windowId }) => {
+  const pendingCapture = previewCaptureTimers.get(windowId);
+  if (pendingCapture?.tabId === tabId) {
+    clearTimeout(pendingCapture.timer);
+    previewCaptureTimers.delete(windowId);
+  }
   void removeCachedPreview(tabId);
 });
 
-chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (changeInfo.url !== undefined) void removeCachedPreview(tabId);
+  if (tab.active && (changeInfo.status === "complete" || changeInfo.url !== undefined)) {
+    schedulePreviewCapture(tabId, tab.windowId);
+  }
+});
+
+chrome.windows.onFocusChanged.addListener((windowId) => {
+  if (windowId === chrome.windows.WINDOW_ID_NONE) return;
+  void chrome.tabs.query({ active: true, windowId }).then(([tab]) => {
+    if (tab?.id !== undefined) schedulePreviewCapture(tab.id, windowId);
+  });
 });
 
 async function openSearchPalette() {
@@ -296,10 +347,14 @@ async function openTabSwitcher() {
   const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   if (!tab) return;
 
-  // Capture before mounting the switcher. Capturing after it opens includes the
-  // switcher itself in the thumbnail, which is especially confusing on repeat use.
-  if (tab.id !== undefined && tab.windowId !== undefined) {
-    await capturePreview(tab.id, tab.windowId);
+  // Active tabs are captured as they settle. Only block the first switcher open
+  // when no preview exists; cached opens remain instantaneous and never capture
+  // the switcher UI itself.
+  if (tab.id !== undefined && !previewCache.has(tab.id)) {
+    const pendingCapture = previewCaptureTimers.get(tab.windowId);
+    if (pendingCapture !== undefined) clearTimeout(pendingCapture.timer);
+    previewCaptureTimers.delete(tab.windowId);
+    await enqueuePreviewCapture(tab.id, tab.windowId);
   }
 
   const [currentTab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,6 @@
 import { parsePreviewEntries, retainOpenTabPreviews, type PreviewEntry } from "./previewCache";
 import { getStoredSettings, pinnedTabIdentity, saveStoredSettings } from "./settings";
-import type { BrowserMessage, PaletteTab } from "./types";
+import type { BookmarkItem, BrowserMessage, PaletteTab } from "./types";
 
 const LEGACY_PREVIEW_CACHE_KEY = "recent-tab-previews";
 const LEGACY_PREVIEW_CACHE_PREFIX = "tab-preview:";
@@ -293,6 +293,38 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   }
 });
 
+function bookmarkFaviconUrl(url: string) {
+  try {
+    return url.startsWith("http")
+      ? `https://www.google.com/s2/favicons?domain=${encodeURIComponent(new URL(url).hostname)}&sz=32`
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function flattenBookmarks(nodes: chrome.bookmarks.BookmarkTreeNode[], folderPath: string[] = []): BookmarkItem[] {
+  return nodes.flatMap((node) => {
+    const nextPath = node.title ? [...folderPath, node.title] : folderPath;
+    if (node.url) {
+      return [{
+        id: node.id,
+        title: node.title.trim() || node.url,
+        url: node.url,
+        folderPath,
+        dateAdded: node.dateAdded,
+        ...(bookmarkFaviconUrl(node.url) ? { faviconUrl: bookmarkFaviconUrl(node.url) } : {}),
+      }];
+    }
+    return node.children ? flattenBookmarks(node.children, nextPath) : [];
+  });
+}
+
+async function getBookmarks(): Promise<BookmarkItem[]> {
+  const tree = await chrome.bookmarks.getTree();
+  return flattenBookmarks(tree).sort((a, b) => (b.dateAdded ?? 0) - (a.dateAdded ?? 0));
+}
+
 async function openSearchPalette() {
   const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
   if (!tab) return;
@@ -344,6 +376,7 @@ chrome.commands.onCommand.addListener((command) => {
   if (command === "open-tab-switcher") void openTabSwitcher();
   if (command === "pin-tab") void sendToActiveTab({ type: "request-pin-selected-tab" });
   if (command === "mute-tab") void sendToActiveTab({ type: "request-mute-selected-tab" });
+  if (command === "open-bookmarks") void sendToActiveTab({ type: "open-palette", mode: "bookmarks" });
 });
 
 chrome.action.onClicked.addListener(() => void openSearchPalette());
@@ -361,6 +394,11 @@ chrome.runtime.onMessage.addListener((message: BrowserMessage, sender, sendRespo
 
   if (message.type === "get-tabs") {
     void getTabs().then(sendResponse);
+    return true;
+  }
+
+  if (message.type === "get-bookmarks") {
+    void getBookmarks().then(sendResponse);
     return true;
   }
 
@@ -403,6 +441,11 @@ chrome.runtime.onMessage.addListener((message: BrowserMessage, sender, sendRespo
       await saveStoredSettings({ pinnedTabs });
     });
     void operation.then(() => sendResponse({ ok: true }), () => sendResponse({ ok: false }));
+    return true;
+  }
+
+  if (message.type === "open-bookmark") {
+    void chrome.tabs.create({ url: message.url }).then(() => sendResponse({ ok: true }));
     return true;
   }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -5,7 +5,6 @@ import type { BrowserMessage, PaletteTab } from "./types";
 const LEGACY_PREVIEW_CACHE_KEY = "recent-tab-previews";
 const LEGACY_PREVIEW_CACHE_PREFIX = "tab-preview:";
 const PREVIEW_CACHE_PREFIX = "tab-preview-v2:";
-const PREVIEW_CAPTURE_DELAY_MS = 250;
 const PREVIEW_CAPTURE_INTERVAL_MS = 550;
 const PREVIEW_MAX_WIDTH = 640;
 const PREVIEW_MAX_HEIGHT = 400;
@@ -34,10 +33,6 @@ function enqueuePinUpdate(update: () => Promise<void>) {
 
 const previewCache = new Map<number, PreviewEntry>();
 const overlayTabIds = new Set<number>();
-const previewCaptureTimers = new Map<number, { tabId: number; timer: ReturnType<typeof setTimeout> }>();
-const pendingPreviewCaptures = new Map<number, { tabId: number; generation: number }>();
-let previewCapturePump: Promise<void> | undefined;
-let previewCaptureGeneration = 0;
 let lastPreviewCaptureStartedAt = 0;
 
 function hostnameFor(url?: string) {
@@ -151,55 +146,6 @@ async function capturePreview(tabId: number, windowId: number) {
     // Restricted browser pages and closed tabs cannot be captured.
     return null;
   }
-}
-
-async function pumpPreviewCaptures() {
-  while (pendingPreviewCaptures.size > 0) {
-    const next = pendingPreviewCaptures.entries().next();
-    if (next.done) break;
-    const [windowId, request] = next.value;
-    const waitMs = Math.max(0, PREVIEW_CAPTURE_INTERVAL_MS - (Date.now() - lastPreviewCaptureStartedAt));
-    if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, waitMs));
-
-    const latest = pendingPreviewCaptures.get(windowId);
-    if (!latest || latest.generation !== request.generation) continue;
-    pendingPreviewCaptures.delete(windowId);
-    lastPreviewCaptureStartedAt = Date.now();
-    await capturePreview(request.tabId, windowId);
-  }
-}
-
-function startPreviewCapturePump() {
-  if (previewCapturePump !== undefined) return;
-  previewCapturePump = pumpPreviewCaptures().finally(() => {
-    previewCapturePump = undefined;
-    startPreviewCapturePump();
-  });
-}
-
-function enqueuePreviewCapture(tabId: number, windowId: number) {
-  previewCaptureGeneration += 1;
-  pendingPreviewCaptures.set(windowId, { tabId, generation: previewCaptureGeneration });
-  startPreviewCapturePump();
-  return previewCapturePump;
-}
-
-function schedulePreviewCapture(tabId: number, windowId: number) {
-  const pendingCapture = previewCaptureTimers.get(windowId);
-  if (pendingCapture !== undefined) clearTimeout(pendingCapture.timer);
-
-  const timer = setTimeout(() => {
-    previewCaptureTimers.delete(windowId);
-    void enqueuePreviewCapture(tabId, windowId);
-  }, PREVIEW_CAPTURE_DELAY_MS);
-  previewCaptureTimers.set(windowId, { tabId, timer });
-}
-
-async function scheduleActiveTabCaptures() {
-  const activeTabs = await chrome.tabs.query({ active: true });
-  activeTabs.forEach((tab) => {
-    if (tab.id !== undefined) schedulePreviewCapture(tab.id, tab.windowId);
-  });
 }
 
 async function sendToTab(tab: chrome.tabs.Tab, message: BrowserMessage) {
@@ -335,20 +281,8 @@ async function getTabs(): Promise<PaletteTab[]> {
 chrome.history.onVisited.addListener(invalidateHistoryCache);
 chrome.history.onVisitRemoved.addListener(invalidateHistoryCache);
 
-chrome.runtime.onInstalled.addListener(() => void scheduleActiveTabCaptures());
-chrome.runtime.onStartup.addListener(() => void scheduleActiveTabCaptures());
-
-chrome.tabs.onActivated.addListener(({ tabId, windowId }) => {
-  schedulePreviewCapture(tabId, windowId);
-});
-
-chrome.tabs.onRemoved.addListener((tabId, { windowId }) => {
+chrome.tabs.onRemoved.addListener((tabId) => {
   overlayTabIds.delete(tabId);
-  const pendingCapture = previewCaptureTimers.get(windowId);
-  if (pendingCapture?.tabId === tabId) {
-    clearTimeout(pendingCapture.timer);
-    previewCaptureTimers.delete(windowId);
-  }
   void removeCachedPreview(tabId);
 });
 
@@ -357,16 +291,6 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     overlayTabIds.delete(tabId);
     void removeCachedPreview(tabId);
   }
-  if (tab.active && (changeInfo.status === "complete" || changeInfo.url !== undefined)) {
-    schedulePreviewCapture(tabId, tab.windowId);
-  }
-});
-
-chrome.windows.onFocusChanged.addListener((windowId) => {
-  if (windowId === chrome.windows.WINDOW_ID_NONE) return;
-  void chrome.tabs.query({ active: true, windowId }).then(([tab]) => {
-    if (tab?.id !== undefined) schedulePreviewCapture(tab.id, windowId);
-  });
 });
 
 async function openSearchPalette() {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,5 @@
 import { pinnedTabIdentity } from "./settings";
-import type { BrowserMessage, PaletteTab, PinnedTab } from "./types";
+import type { BookmarkItem, BrowserMessage, PaletteTab, PinnedTab } from "./types";
 
 export type BrowserHistoryItem = {
   id: string;
@@ -11,6 +11,14 @@ export type BrowserHistoryItem = {
 
 export async function getTabs(): Promise<PaletteTab[]> {
   return chrome.runtime.sendMessage({ type: "get-tabs" } satisfies BrowserMessage);
+}
+
+export async function getBookmarks(): Promise<BookmarkItem[]> {
+  return chrome.runtime.sendMessage({ type: "get-bookmarks" } satisfies BrowserMessage);
+}
+
+export async function openBookmark(url: string) {
+  await chrome.runtime.sendMessage({ type: "open-bookmark", url } satisfies BrowserMessage);
 }
 
 export function notifyPaletteOpened() {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -13,6 +13,25 @@ export async function getTabs(): Promise<PaletteTab[]> {
   return chrome.runtime.sendMessage({ type: "get-tabs" } satisfies BrowserMessage);
 }
 
+export function notifyPaletteOpened() {
+  return chrome.runtime.sendMessage({ type: "palette-opened" } satisfies BrowserMessage);
+}
+
+export function notifyPaletteClosed() {
+  return chrome.runtime.sendMessage({ type: "palette-closed" } satisfies BrowserMessage);
+}
+
+export async function getTabPreviews(tabIds: number[]) {
+  const response: unknown = await chrome.runtime.sendMessage({
+    type: "get-tab-previews",
+    tabIds,
+  } satisfies BrowserMessage);
+  if (typeof response !== "object" || response === null) return {};
+  return Object.fromEntries(Object.entries(response).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  ));
+}
+
 export async function getBrowserHistory(query: string, maxResults = 8): Promise<BrowserHistoryItem[]> {
   return chrome.runtime.sendMessage({ type: "search-history", query, maxResults } satisfies BrowserMessage);
 }

--- a/src/components/BookmarkManager.tsx
+++ b/src/components/BookmarkManager.tsx
@@ -2,6 +2,8 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { getBookmarks, openBookmark } from "../browser";
 import { BookmarkIcon, FolderIcon, GlobeIcon, SearchIcon, XIcon } from "../icons";
 import { useMountEffect } from "../hooks/useMountEffect";
+import { dragPreviewCellForPoint, isAltModifierActive, nextFreeDragPosition, snapPalettePosition } from "../paletteDrag";
+import { saveStoredSettings } from "../settings";
 import type { BookmarkItem, ColorTheme, PalettePosition } from "../types";
 
 function getDisplayDomain(url: string): string {
@@ -54,6 +56,14 @@ export function BookmarkManager({
   const [query, setQuery] = useState("");
   const [selectedFolder, setSelectedFolder] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [dragPosition, setDragPosition] = useState<PalettePosition>();
+  const [dragPreviewCell, setDragPreviewCell] = useState<{ column: number; row: number }>();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const dragRef = useRef<{ pointerId: number; startX: number; startY: number; startPosition: PalettePosition; moved: boolean } | undefined>(undefined);
+  const positionRef = useRef(position);
+  const disableMouseRef = useRef(disableMouse);
+  positionRef.current = position;
+  disableMouseRef.current = disableMouse;
 
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
@@ -128,6 +138,76 @@ export function BookmarkManager({
     [folderTabs, selectedFolder],
   );
 
+  const startDrag = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (disableMouseRef.current || event.button !== 0 || !isAltModifierActive(event)) return;
+    event.preventDefault();
+    dragRef.current = { pointerId: event.pointerId, startX: event.clientX, startY: event.clientY, startPosition: positionRef.current, moved: false };
+    setDragPosition(positionRef.current);
+    setDragPreviewCell(dragPreviewCellForPoint({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    }));
+    try { event.currentTarget.setPointerCapture(event.pointerId); } catch { /* best effort */ }
+  }, []);
+
+  const updateDrag = useCallback((event: PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (Math.abs(event.clientX - drag.startX) > 3 || Math.abs(event.clientY - drag.startY) > 3) drag.moved = true;
+    setDragPosition(nextFreeDragPosition({
+      startX: drag.startX, startY: drag.startY, startPosition: drag.startPosition,
+      clientX: event.clientX, clientY: event.clientY,
+      viewportWidth: window.innerWidth, viewportHeight: window.innerHeight,
+    }));
+    setDragPreviewCell(dragPreviewCellForPoint({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    }));
+  }, []);
+
+  const finishDrag = useCallback((event: PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const card = cardRef.current;
+    const rect = card?.getBoundingClientRect();
+    const nextPosition = snapPalettePosition({
+      ...dragPreviewCellForPoint({
+        clientX: event.clientX, clientY: event.clientY,
+        viewportWidth: window.innerWidth, viewportHeight: window.innerHeight,
+      }),
+      viewportWidth: window.innerWidth, viewportHeight: window.innerHeight,
+      cardWidth: rect?.width ?? 640, cardHeight: rect?.height ?? 320,
+    });
+    dragRef.current = undefined;
+    setDragPosition(undefined);
+    setDragPreviewCell(undefined);
+    if (drag.moved) void saveStoredSettings({ palettePosition: nextPosition });
+  }, []);
+
+  useMountEffect(() => {
+    const move = (event: PointerEvent) => updateDrag(event);
+    const up = (event: PointerEvent) => finishDrag(event);
+    const cancel = () => {
+      dragRef.current = undefined;
+      setDragPosition(undefined);
+      setDragPreviewCell(undefined);
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    window.addEventListener("pointercancel", cancel);
+    window.addEventListener("blur", cancel);
+    return () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+      window.removeEventListener("pointercancel", cancel);
+      window.removeEventListener("blur", cancel);
+    };
+  });
+
   const clearQuery = useCallback(() => {
     setQuery("");
     setSelectedIndex(0);
@@ -187,6 +267,9 @@ export function BookmarkManager({
           event.preventDefault();
           cycleFolderRef.current("prev");
         }
+      } else if (event.key === "Tab") {
+        event.preventDefault();
+        cycleFolderRef.current(event.shiftKey ? "prev" : "next");
       } else if (event.key === "ArrowRight") {
         const isInput = document.activeElement === inputRef.current;
         const atEnd = inputRef.current
@@ -220,15 +303,27 @@ export function BookmarkManager({
         if (event.target === event.currentTarget) onClose();
       }}
     >
+      {dragRef.current && (
+        <div className="palette-placement-grid" aria-hidden="true">
+          {Array.from({ length: 9 }, (_, index) => (
+            <div
+              key={index}
+              className={`palette-placement-cell ${dragPreviewCell?.column === index % 3 && dragPreviewCell?.row === Math.floor(index / 3) ? "is-preview" : ""}`}
+            />
+          ))}
+        </div>
+      )}
       <div
-        className={`palette-card bookmark-card ${isClosing ? "is-closing" : ""}`}
+        className={`palette-card bookmark-card ${dragRef.current ? "is-dragging" : ""} ${isClosing ? "is-closing" : ""}`}
         style={{
-          left: `${position.x * 100}%`,
-          top: `${position.y * 100}%`,
+          left: `${(dragPosition ?? position).x * 100}%`,
+          top: `${(dragPosition ?? position).y * 100}%`,
         }}
+        ref={cardRef}
         role="dialog"
         aria-modal="true"
         aria-label="Bookmarks"
+        onPointerDown={startDrag}
       >
         {/* Minimal Search Row */}
         <div className="search-bar-row">
@@ -238,7 +333,7 @@ export function BookmarkManager({
             <button
               type="button"
               className="bookmark-scope-pill"
-              onClick={() => cycleFolder("next")}
+              onClick={disableMouse ? undefined : () => cycleFolder("next")}
               title="Switch folder (← / →)"
               aria-label={`Current folder: ${selectedFolder ?? "All"}. Press Left or Right arrow to cycle`}
             >

--- a/src/components/BookmarkManager.tsx
+++ b/src/components/BookmarkManager.tsx
@@ -1,0 +1,335 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { getBookmarks, openBookmark } from "../browser";
+import { BookmarkIcon, FolderIcon, GlobeIcon, SearchIcon, XIcon } from "../icons";
+import { useMountEffect } from "../hooks/useMountEffect";
+import type { BookmarkItem, ColorTheme, PalettePosition } from "../types";
+
+function getDisplayDomain(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.hostname.replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+function BookmarkFavicon({ bookmark }: { bookmark: BookmarkItem }) {
+  const [failed, setFailed] = useState(false);
+  const faviconUrl = bookmark.faviconUrl;
+
+  if (!faviconUrl || failed) {
+    return (
+      <span className="bookmark-favicon-fallback" aria-hidden="true">
+        <GlobeIcon size={14} />
+      </span>
+    );
+  }
+
+  return (
+    <img
+      src={faviconUrl}
+      alt=""
+      onError={() => setFailed(true)}
+      loading="lazy"
+    />
+  );
+}
+
+export function BookmarkManager({
+  theme,
+  useVibrancy = true,
+  disableMouse = false,
+  position = { x: 0.5, y: 0.28 },
+  isClosing = false,
+  onClose,
+}: {
+  theme: ColorTheme;
+  useVibrancy?: boolean;
+  disableMouse?: boolean;
+  position?: PalettePosition;
+  isClosing?: boolean;
+  onClose: () => void;
+}) {
+  const [bookmarks, setBookmarks] = useState<BookmarkItem[]>([]);
+  const [query, setQuery] = useState("");
+  const [selectedFolder, setSelectedFolder] = useState<string | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useMountEffect(() => {
+    inputRef.current?.focus();
+    void getBookmarks()
+      .then(setBookmarks)
+      .catch(() => setBookmarks([]));
+  });
+
+  const availableFolders = useMemo(() => {
+    const folderSet = new Set<string>();
+    for (const b of bookmarks) {
+      if (b.folderPath.length > 0) {
+        const last = b.folderPath[b.folderPath.length - 1]?.trim();
+        if (last) folderSet.add(last);
+      }
+    }
+    return Array.from(folderSet);
+  }, [bookmarks]);
+
+  const folderTabs = useMemo(() => ["All", ...availableFolders], [availableFolders]);
+
+  const filteredBookmarks = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    return bookmarks
+      .filter((bookmark) => {
+        if (selectedFolder && !bookmark.folderPath.includes(selectedFolder)) {
+          return false;
+        }
+        if (!normalized) return true;
+        const matchable = `${bookmark.title} ${bookmark.url} ${bookmark.folderPath.join(" ")}`.toLowerCase();
+        return matchable.includes(normalized);
+      })
+      .sort((a, b) => (b.dateAdded ?? 0) - (a.dateAdded ?? 0));
+  }, [bookmarks, query, selectedFolder]);
+
+  const openSelected = useCallback(
+    (bookmark?: BookmarkItem) => {
+      const target = bookmark ?? filteredBookmarks[selectedIndex];
+      if (!target) return;
+      void openBookmark(target.url);
+      onClose();
+    },
+    [filteredBookmarks, selectedIndex, onClose],
+  );
+
+  const updateSelectedIndex = useCallback((nextIndex: number) => {
+    setSelectedIndex(nextIndex);
+    const row = rowRefs.current[nextIndex];
+    if (row) {
+      row.scrollIntoView({ block: "nearest" });
+    }
+  }, []);
+
+  const cycleFolder = useCallback(
+    (direction: "next" | "prev") => {
+      if (folderTabs.length <= 1) return;
+      const current = selectedFolder ?? "All";
+      const currentIdx = folderTabs.indexOf(current);
+      const nextIdx =
+        direction === "next"
+          ? (currentIdx + 1) % folderTabs.length
+          : (currentIdx - 1 + folderTabs.length) % folderTabs.length;
+
+      const nextFolder = folderTabs[nextIdx] === "All" ? null : folderTabs[nextIdx];
+      setSelectedFolder(nextFolder);
+      setSelectedIndex(0);
+    },
+    [folderTabs, selectedFolder],
+  );
+
+  const clearQuery = useCallback(() => {
+    setQuery("");
+    setSelectedIndex(0);
+    inputRef.current?.focus();
+  }, []);
+
+  // Keyboard navigation refs
+  const selectedIndexRef = useRef(selectedIndex);
+  const countRef = useRef(filteredBookmarks.length);
+  const filteredBookmarksRef = useRef(filteredBookmarks);
+  const queryRef = useRef(query);
+  const onCloseRef = useRef(onClose);
+  const cycleFolderRef = useRef(cycleFolder);
+  const updateSelectedIndexRef = useRef(updateSelectedIndex);
+
+  selectedIndexRef.current = selectedIndex;
+  countRef.current = filteredBookmarks.length;
+  filteredBookmarksRef.current = filteredBookmarks;
+  queryRef.current = query;
+  onCloseRef.current = onClose;
+  cycleFolderRef.current = cycleFolder;
+  updateSelectedIndexRef.current = updateSelectedIndex;
+
+  useMountEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        if (queryRef.current) {
+          setQuery("");
+          setSelectedIndex(0);
+          inputRef.current?.focus();
+        } else {
+          onCloseRef.current();
+        }
+      } else if (event.key === "ArrowDown") {
+        event.preventDefault();
+        const count = countRef.current;
+        if (count > 0) {
+          // Wrap around: when reaching the end, go back to start
+          const next = (selectedIndexRef.current + 1) % count;
+          updateSelectedIndexRef.current(next);
+        }
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        const count = countRef.current;
+        if (count > 0) {
+          // Wrap around: when at the start, go to the end
+          const next = (selectedIndexRef.current - 1 + count) % count;
+          updateSelectedIndexRef.current(next);
+        }
+      } else if (event.key === "ArrowLeft") {
+        const isInput = document.activeElement === inputRef.current;
+        const atStart = inputRef.current
+          ? inputRef.current.selectionStart === 0 && inputRef.current.selectionEnd === 0
+          : true;
+        if (!isInput || !queryRef.current || atStart || event.altKey) {
+          event.preventDefault();
+          cycleFolderRef.current("prev");
+        }
+      } else if (event.key === "ArrowRight") {
+        const isInput = document.activeElement === inputRef.current;
+        const atEnd = inputRef.current
+          ? inputRef.current.selectionStart === queryRef.current.length &&
+            inputRef.current.selectionEnd === queryRef.current.length
+          : true;
+        if (!isInput || !queryRef.current || atEnd || event.altKey) {
+          event.preventDefault();
+          cycleFolderRef.current("next");
+        }
+      } else if (event.key === "Enter") {
+        event.preventDefault();
+        const target = filteredBookmarksRef.current[selectedIndexRef.current];
+        if (target) {
+          void openBookmark(target.url);
+          onCloseRef.current();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
+  });
+
+  return (
+    <div
+      className={`palette-backdrop ${isClosing ? "is-closing" : ""}`}
+      data-theme={theme}
+      data-vibrancy={useVibrancy ? "on" : "off"}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        className={`palette-card bookmark-card ${isClosing ? "is-closing" : ""}`}
+        style={{
+          left: `${position.x * 100}%`,
+          top: `${position.y * 100}%`,
+        }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Bookmarks"
+      >
+        {/* Minimal Search Row */}
+        <div className="search-bar-row">
+          <BookmarkIcon size={16} className="search-lead-icon" />
+
+          {availableFolders.length > 0 ? (
+            <button
+              type="button"
+              className="bookmark-scope-pill"
+              onClick={() => cycleFolder("next")}
+              title="Switch folder (← / →)"
+              aria-label={`Current folder: ${selectedFolder ?? "All"}. Press Left or Right arrow to cycle`}
+            >
+              <FolderIcon size={11} className="bookmark-scope-icon" />
+              <span>{selectedFolder ?? "All"}</span>
+              <span className="bookmark-scope-arrow" aria-hidden="true">
+                ▾
+              </span>
+            </button>
+          ) : null}
+
+          <input
+            ref={inputRef}
+            type="text"
+            className="search-input"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setSelectedIndex(0);
+            }}
+            placeholder={selectedFolder ? `Search in ${selectedFolder}...` : "Search bookmarks..."}
+            aria-label="Search bookmarks"
+            autoComplete="off"
+            spellCheck="false"
+          />
+
+          {query ? (
+            <button
+              type="button"
+              className="clear-icon-btn"
+              onClick={clearQuery}
+              aria-label="Clear search"
+            >
+              <XIcon size={13} />
+            </button>
+          ) : null}
+
+          <span className="bookmark-count-pill" aria-label={`${filteredBookmarks.length} bookmarks`}>
+            {filteredBookmarks.length}
+          </span>
+        </div>
+
+        <div className="palette-divider" />
+
+        {/* Bookmark List */}
+        <div
+          ref={listRef}
+          className="bookmark-list"
+          role="listbox"
+          aria-label="Bookmarks"
+        >
+          {filteredBookmarks.length === 0 ? (
+            <div className="bookmark-empty-state">
+              <span>{query ? "No matching bookmarks" : "No bookmarks found"}</span>
+            </div>
+          ) : (
+            filteredBookmarks.map((bookmark, index) => {
+              const isSelected = index === selectedIndex;
+              const domain = getDisplayDomain(bookmark.url);
+
+              return (
+                <div
+                  key={bookmark.id}
+                  ref={(el) => {
+                    rowRefs.current[index] = el;
+                  }}
+                  className={`bookmark-row ${isSelected ? "selected" : ""}`}
+                  role="option"
+                  aria-selected={isSelected}
+                  onMouseEnter={disableMouse ? undefined : () => updateSelectedIndex(index)}
+                  onClick={disableMouse ? undefined : () => openSelected(bookmark)}
+                >
+                  <div className="bookmark-row-left">
+                    <span className="bookmark-favicon">
+                      <BookmarkFavicon bookmark={bookmark} />
+                    </span>
+                    <span className="bookmark-title">{bookmark.title}</span>
+                  </div>
+
+                  <div className="bookmark-row-right">
+                    {domain ? <span className="bookmark-domain">{domain}</span> : null}
+                    <span className="bookmark-return-hint" aria-hidden="true">
+                      ↵
+                    </span>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TabCards.tsx
+++ b/src/components/TabCards.tsx
@@ -13,11 +13,11 @@ type CardProps = {
 };
 
 export function SwitcherCard({ tab, isSelected, previewUrl, index, onClick, onMouseEnter, onToggleMute }: CardProps) {
-  const effectivePreview = tab.previewUrl || (tab.active && tab.windowFocused ? previewUrl : undefined);
+  const effectivePreview = previewUrl;
   return (
     <div data-switcher-index={index} className={`switcher-card ${isSelected ? "is-selected" : ""}`} onClick={onClick} onMouseEnter={onMouseEnter} role="option" aria-selected={isSelected}>
       <div className="switcher-thumbnail">
-        {effectivePreview ? <img src={effectivePreview} alt="" className="switcher-thumbnail-image" loading="eager" /> : (
+        {effectivePreview ? <img src={effectivePreview} alt="" className="switcher-thumbnail-image" loading="eager" decoding="async" /> : (
           <div className="switcher-placeholder">
             <div className="switcher-placeholder-icon"><TabFavicon tab={tab} size={32} /></div>
             <span className="switcher-placeholder-domain">{tab.hostname || "Web Page"}</span>
@@ -36,11 +36,11 @@ export function SwitcherCard({ tab, isSelected, previewUrl, index, onClick, onMo
 }
 
 export function GalleryCard({ tab, index, isSelected, previewUrl, onClick, onMouseEnter, onToggleMute }: CardProps) {
-  const effectivePreview = tab.previewUrl || (tab.active && tab.windowFocused ? previewUrl : undefined);
+  const effectivePreview = previewUrl;
   return (
     <div data-index={index} className={`gallery-card ${isSelected ? "selected" : ""}`} onClick={onClick} onMouseEnter={onMouseEnter} role="option" aria-selected={isSelected}>
       <div className="gallery-thumbnail">
-        {effectivePreview ? <img src={effectivePreview} alt="" className="gallery-thumbnail-image" loading="eager" /> : (
+        {effectivePreview ? <img src={effectivePreview} alt="" className="gallery-thumbnail-image" loading="eager" decoding="async" /> : (
           <div className="gallery-placeholder">
             <TabFavicon tab={tab} size={28} />
             <span className="gallery-placeholder-domain">{tab.hostname || "Web Page"}</span>

--- a/src/content.tsx
+++ b/src/content.tsx
@@ -47,7 +47,6 @@ function openPalette(message: Extract<BrowserMessage, { type: "open-palette" }> 
     <App
       onClose={closePalette}
       initialMode={message.mode}
-      previewUrl={message.previewUrl}
       initialActiveTabId={message.activeTabId}
     />,
   );

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -70,6 +70,33 @@ export function GridIcon({ size = 16, className }: IconProps) {
   );
 }
 
+export function BookmarkIcon({ size = 14, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <path d="M6 4.5A2.5 2.5 0 0 1 8.5 2h7A2.5 2.5 0 0 1 18 4.5V22l-6-3.5L6 22V4.5Z" />
+    </svg>
+  );
+}
+
+export function FolderIcon({ size = 14, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" />
+    </svg>
+  );
+}
+
+export function SortIcon({ size = 14, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+      <path d="m3 16 4 4 4-4" />
+      <path d="M7 20V4" />
+      <path d="m21 8-4-4-4 4" />
+      <path d="M17 4v16" />
+    </svg>
+  );
+}
+
 export function PinIcon({ size = 14, className }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import "./styles.css";
 
 function NewTabPage() {
   const [isOpen, setIsOpen] = useState(false);
-  const [mode, setMode] = useState<"search" | "switcher">("search");
+  const [mode, setMode] = useState<"search" | "switcher" | "bookmarks">("search");
   const [activeTabId, setActiveTabId] = useState<number | undefined>();
   const isOpenRef = useRef(isOpen);
   isOpenRef.current = isOpen;
@@ -36,6 +36,10 @@ function NewTabPage() {
         } else if (e.altKey && e.key.toLowerCase() === "q") {
           e.preventDefault();
           setMode("switcher");
+          setIsOpen(true);
+        } else if (e.altKey && e.key.toLowerCase() === "b") {
+          e.preventDefault();
+          setMode("bookmarks");
           setIsOpen(true);
         }
       }

--- a/src/paletteDrag.ts
+++ b/src/paletteDrag.ts
@@ -1,3 +1,5 @@
+import type { PalettePosition } from "./types";
+
 export function canStartPaletteDrag({
   altKey,
   button,
@@ -8,4 +10,100 @@ export function canStartPaletteDrag({
   mouseDisabled: boolean;
 }) {
   return altKey && button === 0 && !mouseDisabled;
+}
+
+type ModifierKeyName =
+  | "Alt"
+  | "AltGraph"
+  | "CapsLock"
+  | "Control"
+  | "Fn"
+  | "FnLock"
+  | "Hyper"
+  | "Meta"
+  | "NumLock"
+  | "ScrollLock"
+  | "Shift"
+  | "Super"
+  | "Symbol"
+  | "SymbolLock";
+
+type AltModifierSource = {
+  key?: string;
+  altKey?: boolean;
+  getModifierState?: (keyArg: ModifierKeyName) => boolean;
+};
+
+/** True while the Alt/Option modifier is held, tolerating missed key events. */
+export function isAltModifierActive(event: AltModifierSource) {
+  return event.altKey === true || event.key === "Alt" || event.getModifierState?.("Alt") === true;
+}
+
+export function dragPreviewCellForPoint({
+  clientX,
+  clientY,
+  viewportWidth,
+  viewportHeight,
+}: {
+  clientX: number;
+  clientY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}) {
+  if (!(viewportWidth > 0) || !(viewportHeight > 0)) return { column: 1, row: 1 };
+  return {
+    column: Math.min(2, Math.max(0, Math.floor((clientX / viewportWidth) * 3))),
+    row: Math.min(2, Math.max(0, Math.floor((clientY / viewportHeight) * 3))),
+  };
+}
+
+export function nextFreeDragPosition({
+  startX,
+  startY,
+  startPosition,
+  clientX,
+  clientY,
+  viewportWidth,
+  viewportHeight,
+}: {
+  startX: number;
+  startY: number;
+  startPosition: PalettePosition;
+  clientX: number;
+  clientY: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}): PalettePosition {
+  if (!(viewportWidth > 0) || !(viewportHeight > 0)) return startPosition;
+  return {
+    x: Math.min(1, Math.max(0, startPosition.x + (clientX - startX) / viewportWidth)),
+    y: Math.min(1, Math.max(0, startPosition.y + (clientY - startY) / viewportHeight)),
+  };
+}
+
+export function snapPalettePosition({
+  column,
+  row,
+  viewportWidth,
+  viewportHeight,
+  cardWidth,
+  cardHeight,
+}: {
+  column: number;
+  row: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  cardWidth: number;
+  cardHeight: number;
+}): PalettePosition {
+  if (!(viewportWidth > 0) || !(viewportHeight > 0)) return { x: 0.5, y: 0.28 };
+  const x = Math.min(
+    1 - cardWidth / (viewportWidth * 2),
+    Math.max(cardWidth / (viewportWidth * 2), (column + 0.5) / 3),
+  );
+  const y = Math.min(
+    1 - cardHeight / viewportHeight,
+    Math.max(0, (row + 0.5) / 3 - cardHeight / (viewportHeight * 2)),
+  );
+  return { x, y };
 }

--- a/src/paletteDrag.ts
+++ b/src/paletteDrag.ts
@@ -1,9 +1,11 @@
 export function canStartPaletteDrag({
   altKey,
   button,
+  mouseDisabled,
 }: {
   altKey: boolean;
   button: number;
+  mouseDisabled: boolean;
 }) {
-  return altKey && button === 0;
+  return altKey && button === 0 && !mouseDisabled;
 }

--- a/src/paletteDrag.ts
+++ b/src/paletteDrag.ts
@@ -1,0 +1,9 @@
+export function canStartPaletteDrag({
+  altKey,
+  button,
+}: {
+  altKey: boolean;
+  button: number;
+}) {
+  return altKey && button === 0;
+}

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -195,6 +195,14 @@ export function Popup() {
             onChange={(event) => void updateSetting("disableMouseCommandPalette", event.target.checked)}
           />
         </label>
+        <label className="popup-toggle-row">
+          <span>Bookmarks</span>
+          <input
+            type="checkbox"
+            checked={settings.disableMouseBookmarks}
+            onChange={(event) => void updateSetting("disableMouseBookmarks", event.target.checked)}
+          />
+        </label>
       </section>
 
       <section className="popup-shortcuts" aria-label="Keyboard shortcuts">

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -138,6 +138,21 @@ export function Popup() {
         </label>
       </section>
 
+      <section className="popup-section" aria-labelledby="appearance-label">
+        <div className="popup-section-heading">
+          <span id="appearance-label">Appearance</span>
+          <span className="popup-section-context">Overlays</span>
+        </div>
+        <label className="popup-toggle-row">
+          <span>Background vibrancy</span>
+          <input
+            type="checkbox"
+            checked={settings.useVibrancy}
+            onChange={(event) => void updateSetting("useVibrancy", event.target.checked)}
+          />
+        </label>
+      </section>
+
       <section className="popup-section" aria-labelledby="tab-switching-label">
         <div className="popup-section-heading">
           <span id="tab-switching-label">Tab switching</span>

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -15,7 +15,7 @@ export function Popup() {
   const defaultSearchShortcut = isMac ? "⌘⇧P" : "Ctrl Shift P";
   const defaultSwitcherShortcut = isMac ? "⌥Q" : "Alt Q";
   const defaultPinShortcut = isMac ? "⌘K" : "Alt K";
-  const defaultMuteShortcut = isMac ? "⌥M" : "Alt M";
+  const defaultBookmarksShortcut = isMac ? "⌥B" : "Alt B";
   const movePaletteShortcut = isMac ? "⌥ + drag" : "Alt + drag";
   const version = typeof chrome !== "undefined" && chrome.runtime?.getManifest?.()?.version
     ? chrome.runtime.getManifest().version
@@ -54,7 +54,7 @@ export function Popup() {
     { label: "Search tabs", command: "open-palette" as const, fallback: defaultSearchShortcut },
     { label: "Visual switcher", command: "open-tab-switcher" as const, fallback: defaultSwitcherShortcut },
     { label: "Pin selected tab", command: "pin-tab" as const, fallback: defaultPinShortcut },
-    { label: "Mute selected tab", command: "mute-tab" as const, fallback: defaultMuteShortcut },
+    { label: "Bookmark manager", command: "open-bookmarks" as const, fallback: defaultBookmarksShortcut },
   ];
   const unsetCommands = shortcutRows.filter((row) => !shortcuts[row.command]);
 

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -16,6 +16,7 @@ export function Popup() {
   const defaultSwitcherShortcut = isMac ? "⌥Q" : "Alt Q";
   const defaultPinShortcut = isMac ? "⌘K" : "Alt K";
   const defaultMuteShortcut = isMac ? "⌥M" : "Alt M";
+  const movePaletteShortcut = isMac ? "⌥ + drag" : "Alt + drag";
   const version = typeof chrome !== "undefined" && chrome.runtime?.getManifest?.()?.version
     ? chrome.runtime.getManifest().version
     : "0.1.6";
@@ -221,6 +222,12 @@ export function Popup() {
             </span>
           </div>
         ))}
+        <div className="popup-shortcut-row">
+          <span>Move command palette</span>
+          <span className="popup-key-group">
+            <kbd>{movePaletteShortcut}</kbd>
+          </span>
+        </div>
       </section>
 
       <footer className="popup-footer-bar">

--- a/src/previewCache.ts
+++ b/src/previewCache.ts
@@ -1,0 +1,33 @@
+export type PreviewEntry = {
+  tabId: number;
+  url: string;
+  dataUrl: string;
+  capturedAt: number;
+};
+
+type OpenTab = {
+  id: number;
+  url?: string;
+};
+
+export function parsePreviewEntries(value: unknown) {
+  if (!Array.isArray(value)) return [];
+
+  return value.filter((entry): entry is PreviewEntry =>
+    typeof entry === "object" &&
+    entry !== null &&
+    "tabId" in entry &&
+    typeof entry.tabId === "number" &&
+    "url" in entry &&
+    typeof entry.url === "string" &&
+    "dataUrl" in entry &&
+    typeof entry.dataUrl === "string" &&
+    "capturedAt" in entry &&
+    typeof entry.capturedAt === "number"
+  );
+}
+
+export function retainOpenTabPreviews(entries: Iterable<PreviewEntry>, tabs: Iterable<OpenTab>) {
+  const openTabUrls = new Map([...tabs].map((tab) => [tab.id, tab.url]));
+  return [...entries].filter((entry) => openTabUrls.get(entry.tabId) === entry.url);
+}

--- a/src/previewCache.ts
+++ b/src/previewCache.ts
@@ -22,6 +22,7 @@ export function parsePreviewEntries(value: unknown) {
     typeof entry.url === "string" &&
     "dataUrl" in entry &&
     typeof entry.dataUrl === "string" &&
+    entry.dataUrl.startsWith("data:") &&
     "capturedAt" in entry &&
     typeof entry.capturedAt === "number"
   );
@@ -30,4 +31,11 @@ export function parsePreviewEntries(value: unknown) {
 export function retainOpenTabPreviews(entries: Iterable<PreviewEntry>, tabs: Iterable<OpenTab>) {
   const openTabUrls = new Map([...tabs].map((tab) => [tab.id, tab.url]));
   return [...entries].filter((entry) => openTabUrls.get(entry.tabId) === entry.url);
+}
+
+export function stalePreviewTabIds(previousTabs: Iterable<OpenTab>, nextTabs: Iterable<OpenTab>) {
+  const nextTabUrls = new Map([...nextTabs].map((tab) => [tab.id, tab.url]));
+  return [...previousTabs]
+    .filter((tab) => nextTabUrls.get(tab.id) !== tab.url)
+    .map((tab) => tab.id);
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   useVibrancy: true,
   disableMouseTabSwitcher: false,
   disableMouseCommandPalette: false,
+  disableMouseBookmarks: false,
   tabSwitchMode: "recent",
   pinnedTabs: [],
   palettePosition: { x: 0.5, y: 0.28 },
@@ -231,6 +232,9 @@ export function parseStoredSettings(value: unknown): UserSettings {
   const disableMouseCommandPalette = "disableMouseCommandPalette" in value && isBoolean(value.disableMouseCommandPalette)
     ? value.disableMouseCommandPalette
     : DEFAULT_SETTINGS.disableMouseCommandPalette;
+  const disableMouseBookmarks = "disableMouseBookmarks" in value && isBoolean(value.disableMouseBookmarks)
+    ? value.disableMouseBookmarks
+    : DEFAULT_SETTINGS.disableMouseBookmarks;
   const tabSwitchMode = "tabSwitchMode" in value && isTabSwitchMode(value.tabSwitchMode)
     ? value.tabSwitchMode
     : DEFAULT_SETTINGS.tabSwitchMode;
@@ -240,7 +244,7 @@ export function parseStoredSettings(value: unknown): UserSettings {
       ? parseLegacyPinnedTabs(value.pinnedTabIds)
       : DEFAULT_SETTINGS.pinnedTabs;
   const palettePosition = "palettePosition" in value ? parsePalettePosition(value.palettePosition) : DEFAULT_SETTINGS.palettePosition;
-  return { viewMode, theme, useVibrancy, disableMouseTabSwitcher, disableMouseCommandPalette, tabSwitchMode, pinnedTabs, palettePosition };
+  return { viewMode, theme, useVibrancy, disableMouseTabSwitcher, disableMouseCommandPalette, disableMouseBookmarks, tabSwitchMode, pinnedTabs, palettePosition };
 }
 
 function parseSettingsUpdate(value: unknown): Partial<UserSettings> {
@@ -254,6 +258,9 @@ function parseSettingsUpdate(value: unknown): Partial<UserSettings> {
       : {}),
     ...( "disableMouseCommandPalette" in value && isBoolean(value.disableMouseCommandPalette)
       ? { disableMouseCommandPalette: value.disableMouseCommandPalette }
+      : {}),
+    ...( "disableMouseBookmarks" in value && isBoolean(value.disableMouseBookmarks)
+      ? { disableMouseBookmarks: value.disableMouseBookmarks }
       : {}),
     ...( "tabSwitchMode" in value && isTabSwitchMode(value.tabSwitchMode)
       ? { tabSwitchMode: value.tabSwitchMode }
@@ -299,6 +306,7 @@ async function readChromeLocalSettings() {
     "useVibrancy",
     "disableMouseTabSwitcher",
     "disableMouseCommandPalette",
+    "disableMouseBookmarks",
     "tabSwitchMode",
     "pinnedTabs",
     "pinnedTabIds",
@@ -328,6 +336,7 @@ export async function getStoredSettings(): Promise<UserSettings> {
         "useVibrancy",
         "disableMouseTabSwitcher",
         "disableMouseCommandPalette",
+        "disableMouseBookmarks",
         "tabSwitchMode",
         "pinnedTabs",
         "pinnedTabIds",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import type { ColorTheme, PalettePosition, PinnedTab, TabSwitchMode, UserSetting
 export const DEFAULT_SETTINGS: UserSettings = {
   viewMode: "list",
   theme: "default",
+  useVibrancy: true,
   disableMouseTabSwitcher: false,
   disableMouseCommandPalette: false,
   tabSwitchMode: "recent",
@@ -221,6 +222,9 @@ export function parseStoredSettings(value: unknown): UserSettings {
   if (typeof value !== "object" || value === null) return DEFAULT_SETTINGS;
   const viewMode = "viewMode" in value && isViewMode(value.viewMode) ? value.viewMode : DEFAULT_SETTINGS.viewMode;
   const theme = "theme" in value ? parseColorTheme(value.theme) : DEFAULT_SETTINGS.theme;
+  const useVibrancy = "useVibrancy" in value && isBoolean(value.useVibrancy)
+    ? value.useVibrancy
+    : DEFAULT_SETTINGS.useVibrancy;
   const disableMouseTabSwitcher = "disableMouseTabSwitcher" in value && isBoolean(value.disableMouseTabSwitcher)
     ? value.disableMouseTabSwitcher
     : DEFAULT_SETTINGS.disableMouseTabSwitcher;
@@ -236,7 +240,7 @@ export function parseStoredSettings(value: unknown): UserSettings {
       ? parseLegacyPinnedTabs(value.pinnedTabIds)
       : DEFAULT_SETTINGS.pinnedTabs;
   const palettePosition = "palettePosition" in value ? parsePalettePosition(value.palettePosition) : DEFAULT_SETTINGS.palettePosition;
-  return { viewMode, theme, disableMouseTabSwitcher, disableMouseCommandPalette, tabSwitchMode, pinnedTabs, palettePosition };
+  return { viewMode, theme, useVibrancy, disableMouseTabSwitcher, disableMouseCommandPalette, tabSwitchMode, pinnedTabs, palettePosition };
 }
 
 function parseSettingsUpdate(value: unknown): Partial<UserSettings> {
@@ -244,6 +248,7 @@ function parseSettingsUpdate(value: unknown): Partial<UserSettings> {
   return {
     ...( "viewMode" in value && isViewMode(value.viewMode) ? { viewMode: value.viewMode } : {}),
     ...( "theme" in value && isColorTheme(value.theme) ? { theme: value.theme } : {}),
+    ...( "useVibrancy" in value && isBoolean(value.useVibrancy) ? { useVibrancy: value.useVibrancy } : {}),
     ...( "disableMouseTabSwitcher" in value && isBoolean(value.disableMouseTabSwitcher)
       ? { disableMouseTabSwitcher: value.disableMouseTabSwitcher }
       : {}),
@@ -291,6 +296,7 @@ async function readChromeLocalSettings() {
   const stored: unknown = await chrome.storage.local.get([
     "viewMode",
     "theme",
+    "useVibrancy",
     "disableMouseTabSwitcher",
     "disableMouseCommandPalette",
     "tabSwitchMode",
@@ -319,6 +325,7 @@ export async function getStoredSettings(): Promise<UserSettings> {
       const settings = parseStoredSettings(await chrome.storage.sync.get([
         "viewMode",
         "theme",
+        "useVibrancy",
         "disableMouseTabSwitcher",
         "disableMouseCommandPalette",
         "tabSwitchMode",

--- a/src/styles.css
+++ b/src/styles.css
@@ -284,6 +284,264 @@ button {
   animation: backdrop-exit 130ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
 }
 
+/* ========================================================================
+   Bookmark Manager (Alt + B)
+   ========================================================================== */
+
+.bookmark-card {
+  position: absolute;
+  z-index: 2;
+  transform: translateX(-50%);
+  width: min(calc(100vw - 32px), 600px);
+  max-height: min(80vh, 600px);
+  background: var(--bg-panel);
+  backdrop-filter: blur(40px) saturate(190%);
+  -webkit-backdrop-filter: blur(40px) saturate(190%);
+  border: 1px solid var(--border-panel);
+  border-radius: 16px;
+  box-shadow:
+    0 4px 20px -2px rgba(0, 0, 0, 0.5),
+    0 24px 70px -12px rgba(0, 0, 0, 0.9),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transform-origin: top center;
+  will-change: transform, opacity, box-shadow;
+  animation: bookmark-card-entry 160ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  transition:
+    box-shadow 160ms ease,
+    border-color 140ms ease;
+}
+
+.bookmark-card.is-closing {
+  animation: palette-card-exit 120ms cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+
+@keyframes bookmark-card-entry {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) scale(0.97) translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) scale(1) translateY(0);
+  }
+}
+
+/* Inline Folder Scope Pill */
+.bookmark-scope-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 24px;
+  padding: 0 8px;
+  border-radius: 6px;
+  font-size: 11.5px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--text-secondary);
+  background: var(--bg-card);
+  border: 1px solid var(--border-card);
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+  transition:
+    color 100ms ease,
+    background-color 100ms ease,
+    border-color 100ms ease,
+    transform 80ms ease;
+}
+
+.bookmark-scope-pill:hover {
+  color: var(--text-primary);
+  background: var(--bg-card-hover);
+  border-color: var(--border-panel);
+}
+
+.bookmark-scope-pill:active {
+  transform: scale(0.97);
+}
+
+.bookmark-scope-icon {
+  color: var(--text-muted);
+  opacity: 0.8;
+  transition: color 100ms ease;
+}
+
+.bookmark-scope-pill:hover .bookmark-scope-icon {
+  color: var(--accent-primary);
+}
+
+.bookmark-scope-arrow {
+  font-size: 8px;
+  color: var(--text-muted);
+  margin-left: 1px;
+}
+
+/* Bookmarks List */
+.bookmark-list {
+  max-height: min(400px, calc(75vh - 90px));
+  min-height: 80px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scroll-padding-block: 4px;
+  padding: 4px 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.bookmark-list::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+/* Individual Bookmark Row */
+.bookmark-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  height: 40px;
+  min-height: 40px;
+  padding: 0 10px;
+  border-radius: 8px;
+  color: var(--text-primary);
+  border: 1px solid transparent;
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color 80ms ease,
+    border-color 80ms ease;
+}
+
+.bookmark-row:hover {
+  background: var(--bg-card-hover);
+}
+
+.bookmark-row.selected {
+  background: var(--bg-selected);
+  border-color: var(--border-selected);
+}
+
+.bookmark-row-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+}
+
+.bookmark-favicon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.bookmark-favicon img {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+}
+
+.bookmark-favicon-fallback {
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.bookmark-title {
+  font-size: 13.5px;
+  font-weight: 450;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bookmark-row.selected .bookmark-title {
+  font-weight: 550;
+}
+
+.bookmark-row-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.bookmark-domain {
+  font-size: 12px;
+  color: var(--text-muted);
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.bookmark-return-hint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 100ms ease;
+}
+
+.bookmark-row.selected .bookmark-return-hint {
+  opacity: 1;
+  color: var(--text-primary);
+}
+
+/* Empty State */
+.bookmark-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 36px 20px;
+  text-align: center;
+  color: var(--text-muted);
+  user-select: none;
+}
+
+.bookmark-empty-state span {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.bookmark-count-pill {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--text-muted);
+  background: var(--bg-card);
+  border: 1px solid var(--border-card);
+  padding: 2px 7px;
+  border-radius: 6px;
+  line-height: 1.2;
+  user-select: none;
+  flex-shrink: 0;
+  transition:
+    color 120ms ease,
+    background-color 120ms ease;
+}
+
 /* ==========================================================================
    Horizontal Thumbnail Switcher HUD (Alt + Q)
    ========================================================================== */
@@ -1549,6 +1807,13 @@ kbd {
     border-color: var(--border-selected);
   }
 
+  .palette-backdrop[data-theme="default"] .bookmark-card {
+    box-shadow:
+      0 4px 20px -2px rgba(0, 0, 0, 0.08),
+      0 24px 70px -12px rgba(0, 0, 0, 0.16),
+      inset 0 1px 0 rgba(255, 255, 255, 0.85);
+  }
+
   .palette-backdrop[data-theme="default"] .clear-icon-btn,
   .palette-backdrop[data-theme="default"] .expand-toggle-btn {
     color: var(--text-muted);
@@ -1561,24 +1826,31 @@ kbd {
 }
 
 .palette-backdrop[data-vibrancy="on"] {
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  background: rgba(0, 0, 0, 0.45);
 }
 
-.palette-backdrop[data-vibrancy="on"] .palette-card {
-  background: color-mix(in srgb, var(--bg-canvas) 74%, transparent);
-  backdrop-filter: blur(18px) saturate(160%);
-  -webkit-backdrop-filter: blur(18px) saturate(160%);
+.palette-backdrop[data-vibrancy="on"] .palette-card,
+.palette-backdrop[data-vibrancy="on"] .bookmark-card {
+  background: color-mix(in srgb, var(--bg-panel) 82%, transparent);
+  backdrop-filter: blur(42px) saturate(190%) contrast(105%);
+  -webkit-backdrop-filter: blur(42px) saturate(190%) contrast(105%);
+  box-shadow:
+    0 4px 20px -2px rgba(0, 0, 0, 0.5),
+    0 24px 70px -12px rgba(0, 0, 0, 0.9),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
 
 .palette-backdrop[data-vibrancy="on"] .switcher-hud {
-  background: color-mix(in srgb, var(--bg-canvas) 70%, transparent);
-  backdrop-filter: blur(20px) saturate(165%);
-  -webkit-backdrop-filter: blur(20px) saturate(165%);
+  background: color-mix(in srgb, var(--bg-hud) 80%, transparent);
+  backdrop-filter: blur(44px) saturate(190%) contrast(105%);
+  -webkit-backdrop-filter: blur(44px) saturate(190%) contrast(105%);
 }
 
 @media (prefers-reduced-transparency: reduce) {
-  .palette-backdrop[data-vibrancy="on"] .palette-card {
+  .palette-backdrop[data-vibrancy="on"] .palette-card,
+  .palette-backdrop[data-vibrancy="on"] .bookmark-card {
     background: var(--bg-panel);
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
@@ -1595,9 +1867,12 @@ kbd {
   .palette-backdrop,
   .switcher-hud,
   .palette-card,
+  .bookmark-card,
   .palette-divider,
   .item-list,
-  .empty-state {
+  .bookmark-list,
+  .empty-state,
+  .bookmark-empty-state {
     animation: none;
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -517,8 +517,15 @@ button {
   color: var(--accent-primary);
 }
 
-.palette-card.is-dragging .search-bar-row {
-  cursor: grabbing;
+.palette-card.is-drag-ready,
+.palette-card.is-drag-ready * {
+  cursor: grab !important;
+}
+
+.palette-card.is-dragging,
+.palette-card.is-dragging * {
+  cursor: grabbing !important;
+  user-select: none;
 }
 
 .palette-placement-grid {

--- a/src/styles.css
+++ b/src/styles.css
@@ -321,7 +321,7 @@ button {
   scrollbar-width: none;
   -ms-overflow-style: none;
   padding: 8px 6px 12px;
-  scroll-behavior: smooth;
+  scroll-behavior: auto;
   scroll-snap-type: x proximity;
   scroll-padding-inline: 6px;
   overscroll-behavior-x: contain;
@@ -351,10 +351,10 @@ button {
   opacity: 0.6;
   transform: scale(0.96);
   transition:
-    transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
-    opacity 180ms cubic-bezier(0.16, 1, 0.3, 1),
-    background-color 160ms ease,
-    border-color 160ms ease;
+    transform 95ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 95ms cubic-bezier(0.16, 1, 0.3, 1),
+    background-color 90ms ease,
+    border-color 90ms ease;
 }
 
 .switcher-card:hover {
@@ -1525,6 +1525,37 @@ kbd {
   .palette-backdrop[data-theme="default"] .clear-icon-btn:hover,
   .palette-backdrop[data-theme="default"] .expand-toggle-btn:hover {
     color: var(--text-primary);
+  }
+}
+
+.palette-backdrop[data-vibrancy="on"] {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.palette-backdrop[data-vibrancy="on"] .palette-card {
+  background: color-mix(in srgb, var(--bg-canvas) 74%, transparent);
+  backdrop-filter: blur(18px) saturate(160%);
+  -webkit-backdrop-filter: blur(18px) saturate(160%);
+}
+
+.palette-backdrop[data-vibrancy="on"] .switcher-hud {
+  background: color-mix(in srgb, var(--bg-canvas) 70%, transparent);
+  backdrop-filter: blur(20px) saturate(165%);
+  -webkit-backdrop-filter: blur(20px) saturate(165%);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .palette-backdrop[data-vibrancy="on"] .palette-card {
+    background: var(--bg-panel);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  .palette-backdrop[data-vibrancy="on"] .switcher-hud {
+    background: var(--bg-hud);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -520,12 +520,34 @@ button {
 .palette-card.is-drag-ready,
 .palette-card.is-drag-ready * {
   cursor: grab !important;
+  user-select: none;
+}
+
+/* While Alt is held the whole card is a drag surface: interactive children
+   (input, buttons, rows) stop receiving pointer events so Alt+drag can only
+   move the palette, never focus, select, or activate anything. */
+.palette-card.is-drag-ready input,
+.palette-card.is-drag-ready button,
+.palette-card.is-drag-ready select,
+.palette-card.is-drag-ready textarea,
+.palette-card.is-drag-ready a,
+.palette-card.is-drag-ready [role="button"],
+.palette-card.is-drag-ready [role="option"],
+.palette-card.is-dragging input,
+.palette-card.is-dragging button,
+.palette-card.is-dragging select,
+.palette-card.is-dragging textarea,
+.palette-card.is-dragging a,
+.palette-card.is-dragging [role="button"],
+.palette-card.is-dragging [role="option"] {
+  pointer-events: none;
 }
 
 .palette-card.is-dragging,
 .palette-card.is-dragging * {
   cursor: grabbing !important;
   user-select: none;
+  touch-action: none;
 }
 
 .palette-placement-grid {
@@ -609,9 +631,12 @@ button {
 
 /* Items List (List View) */
 .item-list {
-  max-height: 380px;
+  max-height: min(380px, calc(100vh - 110px));
+  min-height: 0;
   overflow-y: auto;
-  padding: 6px 8px 8px;
+  overscroll-behavior: contain;
+  scroll-padding-block: 8px 24px;
+  padding: 6px 8px 24px;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -794,8 +819,8 @@ button {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
-  padding: 16px 14px 20px;
-  max-height: 480px;
+  padding: 16px 14px 24px;
+  max-height: min(480px, calc(100vh - 110px));
 }
 
 .gallery-card {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type UserSettings = {
   useVibrancy: boolean;
   disableMouseTabSwitcher: boolean;
   disableMouseCommandPalette: boolean;
+  disableMouseBookmarks: boolean;
   tabSwitchMode: TabSwitchMode;
   pinnedTabs: PinnedTab[];
   palettePosition: PalettePosition;

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export type PinnedTab = {
 export type UserSettings = {
   viewMode: ViewMode;
   theme: ColorTheme;
+  useVibrancy: boolean;
   disableMouseTabSwitcher: boolean;
   disableMouseCommandPalette: boolean;
   tabSwitchMode: TabSwitchMode;
@@ -48,7 +49,6 @@ export type PaletteTab = {
   hostname: string;
   index: number;
   faviconUrl?: string;
-  previewUrl?: string;
   active: boolean;
   windowFocused: boolean;
   pinned: boolean;
@@ -59,14 +59,16 @@ export type PaletteTab = {
 
 export type BrowserMessage =
   | { type: "get-tabs" }
+  | { type: "get-tab-previews"; tabIds: number[] }
+  | { type: "palette-opened" }
+  | { type: "palette-closed" }
   | { type: "search-history"; query: string; maxResults?: number }
   | { type: "activate-tab"; tab: PaletteTab }
   | { type: "toggle-tab-muted"; tabId: number; muted: boolean }
   | { type: "open-url"; url: string; openerTabId?: number }
   | { type: "search-web"; query: string }
   | { type: "open-shortcut-settings" }
-  | { type: "open-palette"; mode?: "search" | "switcher"; previewUrl?: string; activeTabId?: number }
-  | { type: "update-switcher-preview"; previewUrl: string }
+  | { type: "open-palette"; mode?: "search" | "switcher"; activeTabId?: number }
   | { type: "cycle-tab-switcher"; direction?: "next" | "prev" }
   | { type: "request-pin-selected-tab" }
   | { type: "request-mute-selected-tab" }

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,15 @@ export type UserSettings = {
   palettePosition: PalettePosition;
 };
 
+export type BookmarkItem = {
+  id: string;
+  title: string;
+  url: string;
+  folderPath: string[];
+  dateAdded?: number;
+  faviconUrl?: string;
+};
+
 export type PaletteTab = {
   id: number;
   windowId: number;
@@ -68,10 +77,12 @@ export type BrowserMessage =
   | { type: "open-url"; url: string; openerTabId?: number }
   | { type: "search-web"; query: string }
   | { type: "open-shortcut-settings" }
-  | { type: "open-palette"; mode?: "search" | "switcher"; activeTabId?: number }
+  | { type: "open-palette"; mode?: "search" | "switcher" | "bookmarks"; activeTabId?: number }
   | { type: "cycle-tab-switcher"; direction?: "next" | "prev" }
   | { type: "request-pin-selected-tab" }
   | { type: "request-mute-selected-tab" }
+  | { type: "get-bookmarks" }
+  | { type: "open-bookmark"; url: string }
   | { type: "set-tab-pinned"; tab: PinnedTab; pinned: boolean }
   | { type: "get-settings" }
   | { type: "save-settings"; settings: Partial<UserSettings> };

--- a/tests/paletteDrag.test.ts
+++ b/tests/paletteDrag.test.ts
@@ -3,7 +3,8 @@ import test from "node:test";
 import { canStartPaletteDrag } from "../src/paletteDrag.ts";
 
 test("starts palette dragging only for Alt plus primary pointer", () => {
-  assert.equal(canStartPaletteDrag({ altKey: true, button: 0 }), true);
-  assert.equal(canStartPaletteDrag({ altKey: false, button: 0 }), false);
-  assert.equal(canStartPaletteDrag({ altKey: true, button: 1 }), false);
+  assert.equal(canStartPaletteDrag({ altKey: true, button: 0, mouseDisabled: false }), true);
+  assert.equal(canStartPaletteDrag({ altKey: false, button: 0, mouseDisabled: false }), false);
+  assert.equal(canStartPaletteDrag({ altKey: true, button: 1, mouseDisabled: false }), false);
+  assert.equal(canStartPaletteDrag({ altKey: true, button: 0, mouseDisabled: true }), false);
 });

--- a/tests/paletteDrag.test.ts
+++ b/tests/paletteDrag.test.ts
@@ -1,10 +1,96 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { canStartPaletteDrag } from "../src/paletteDrag.ts";
+import {
+  canStartPaletteDrag,
+  dragPreviewCellForPoint,
+  isAltModifierActive,
+  nextFreeDragPosition,
+  snapPalettePosition,
+} from "../src/paletteDrag.ts";
 
 test("starts palette dragging only for Alt plus primary pointer", () => {
   assert.equal(canStartPaletteDrag({ altKey: true, button: 0, mouseDisabled: false }), true);
   assert.equal(canStartPaletteDrag({ altKey: false, button: 0, mouseDisabled: false }), false);
   assert.equal(canStartPaletteDrag({ altKey: true, button: 1, mouseDisabled: false }), false);
   assert.equal(canStartPaletteDrag({ altKey: true, button: 0, mouseDisabled: true }), false);
+});
+
+test("alt modifier is detected from key, flag, or modifier state", () => {
+  assert.equal(isAltModifierActive({ key: "Alt", altKey: false }), true);
+  assert.equal(isAltModifierActive({ key: "m", altKey: true }), true);
+  assert.equal(
+    isAltModifierActive({ key: "Unidentified", altKey: false, getModifierState: () => true }),
+    true,
+  );
+  assert.equal(isAltModifierActive({ key: "a", altKey: false }), false);
+  assert.equal(
+    isAltModifierActive({ key: "a", altKey: false, getModifierState: () => false }),
+    false,
+  );
+});
+
+test("free drag position follows the pointer delta and clamps to the viewport", () => {
+  assert.deepEqual(
+    nextFreeDragPosition({
+      startX: 100,
+      startY: 100,
+      startPosition: { x: 0.5, y: 0.28 },
+      clientX: 200,
+      clientY: 150,
+      viewportWidth: 1000,
+      viewportHeight: 800,
+    }),
+    { x: 0.6, y: 0.3425 },
+  );
+  assert.deepEqual(
+    nextFreeDragPosition({
+      startX: 100,
+      startY: 100,
+      startPosition: { x: 0.5, y: 0.28 },
+      clientX: -2000,
+      clientY: 5000,
+      viewportWidth: 1000,
+      viewportHeight: 800,
+    }),
+    { x: 0, y: 1 },
+  );
+});
+
+test("snap position centers the release cell and keeps the card on screen", () => {
+  const centered = snapPalettePosition({
+    column: 1,
+    row: 1,
+    viewportWidth: 1200,
+    viewportHeight: 800,
+    cardWidth: 640,
+    cardHeight: 54,
+  });
+  assert.ok(Math.abs(centered.x - 0.5) < 1e-9);
+  assert.ok(Math.abs(centered.y - (0.5 - 54 / 1600)) < 1e-9);
+
+  const corner = snapPalettePosition({
+    column: 0,
+    row: 0,
+    viewportWidth: 1200,
+    viewportHeight: 800,
+    cardWidth: 640,
+    cardHeight: 54,
+  });
+  assert.ok(corner.x >= 640 / 2400);
+  assert.ok(corner.y >= 0);
+});
+
+test("preview cell maps pointer points to the 3x3 grid", () => {
+  assert.deepEqual(
+    dragPreviewCellForPoint({ clientX: 10, clientY: 10, viewportWidth: 900, viewportHeight: 900 }),
+    { column: 0, row: 0 },
+  );
+  assert.deepEqual(
+    dragPreviewCellForPoint({ clientX: 450, clientY: 450, viewportWidth: 900, viewportHeight: 900 }),
+    { column: 1, row: 1 },
+  );
+  assert.deepEqual(
+    dragPreviewCellForPoint({ clientX: 899, clientY: 899, viewportWidth: 900, viewportHeight: 900 }),
+    { column: 2, row: 2 },
+  );
 });

--- a/tests/paletteDrag.test.ts
+++ b/tests/paletteDrag.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { canStartPaletteDrag } from "../src/paletteDrag.ts";
+
+test("starts palette dragging only for Alt plus primary pointer", () => {
+  assert.equal(canStartPaletteDrag({ altKey: true, button: 0 }), true);
+  assert.equal(canStartPaletteDrag({ altKey: false, button: 0 }), false);
+  assert.equal(canStartPaletteDrag({ altKey: true, button: 1 }), false);
+});

--- a/tests/previewCache.test.ts
+++ b/tests/previewCache.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { retainOpenTabPreviews, type PreviewEntry } from "../src/previewCache.ts";
+
+test("retains a preview for every open tab without a fixed cache limit", () => {
+  const previews: PreviewEntry[] = Array.from({ length: 100 }, (_, index) => ({
+    tabId: index + 1,
+    url: `https://example.com/${index + 1}`,
+    dataUrl: `data:image/jpeg;base64,preview-${index + 1}`,
+    capturedAt: index,
+  }));
+  const tabs = previews.map(({ tabId: id, url }) => ({ id, url }));
+
+  assert.equal(retainOpenTabPreviews(previews, tabs).length, tabs.length);
+});
+
+test("removes previews for closed or navigated tabs", () => {
+  const previews: PreviewEntry[] = [
+    { tabId: 1, url: "https://old.example", dataUrl: "old", capturedAt: 1 },
+    { tabId: 2, url: "https://closed.example", dataUrl: "closed", capturedAt: 2 },
+    { tabId: 3, url: "https://current.example", dataUrl: "current", capturedAt: 3 },
+  ];
+
+  assert.deepEqual(
+    retainOpenTabPreviews(previews, [
+      { id: 1, url: "https://new.example" },
+      { id: 3, url: "https://current.example" },
+    ]),
+    [previews[2]],
+  );
+});

--- a/tests/previewCache.test.ts
+++ b/tests/previewCache.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { retainOpenTabPreviews, type PreviewEntry } from "../src/previewCache.ts";
+import { parsePreviewEntries, retainOpenTabPreviews, stalePreviewTabIds, type PreviewEntry } from "../src/previewCache.ts";
+
+test("rejects preview entries without data URLs", () => {
+  assert.deepEqual(parsePreviewEntries([
+    { tabId: 1, url: "https://example.com", dataUrl: "broken", capturedAt: 1 },
+    { tabId: 2, url: "https://example.com", dataUrl: "data:image/webp;base64,valid", capturedAt: 2 },
+  ]), [{ tabId: 2, url: "https://example.com", dataUrl: "data:image/webp;base64,valid", capturedAt: 2 }]);
+});
 
 test("retains a preview for every open tab without a fixed cache limit", () => {
   const previews: PreviewEntry[] = Array.from({ length: 100 }, (_, index) => ({
@@ -12,6 +19,16 @@ test("retains a preview for every open tab without a fixed cache limit", () => {
   const tabs = previews.map(({ tabId: id, url }) => ({ id, url }));
 
   assert.equal(retainOpenTabPreviews(previews, tabs).length, tabs.length);
+});
+
+test("identifies preview entries invalidated by navigation or tab closure", () => {
+  assert.deepEqual(
+    stalePreviewTabIds(
+      [{ id: 1, url: "https://old.example" }, { id: 2, url: "https://closed.example" }],
+      [{ id: 1, url: "https://new.example" }, { id: 3, url: "https://added.example" }],
+    ),
+    [1, 2],
+  );
 });
 
 test("removes previews for closed or navigated tabs", () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -65,9 +65,10 @@ test("persisted settings validate fields independently", () => {
     DEFAULT_SETTINGS,
   );
   assert.deepEqual(
-    parseStoredSettings({ disableMouseTabSwitcher: true, disableMouseCommandPalette: "yes", pinnedTabs: [{ tabId: 12, url: "https://example.com" }, { tabId: 0, url: "bad" }] }),
+    parseStoredSettings({ useVibrancy: false, disableMouseTabSwitcher: true, disableMouseCommandPalette: "yes", pinnedTabs: [{ tabId: 12, url: "https://example.com" }, { tabId: 0, url: "bad" }] }),
     {
       ...DEFAULT_SETTINGS,
+      useVibrancy: false,
       disableMouseTabSwitcher: true,
       pinnedTabs: [{
         tabId: 12,


### PR DESCRIPTION
## Summary
- add optional background vibrancy for the command palette and tab switcher
- remove queued switcher work and stacked scrolling animations
- load only nearby previews instead of serializing every thumbnail
- grant narrow active-tab capture access and prevent recursive overlay captures
- increase cached preview quality and invalidate contaminated legacy previews

## Checks
- `pnpm test`
- `pnpm exec tsc --noEmit`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the command palette and tab switcher, restores tab thumbnails that had stopped appearing, and adds a bookmark manager with keyboard navigation and drag repositioning.

- Preview thumbnails load only for nearby tabs instead of serializing every open tab.
- Captures now require `activeTab`, happen only on user-triggered switcher opens, skip the overlay tab, and are rate-limited.
- Dropped queued switcher work and stacked scrolling animations so the switcher opens immediately.
- Previews are invalidated when tabs navigate, stored as higher-quality WebP, and legacy cache entries are removed on startup.
- Palette repositions with Alt+drag (Option on macOS) instead of plain drag.

**New Features**
- Alt+B opens a bookmark manager with search, folder scoping, keyboard navigation, and Alt+drag repositioning; this adds the `bookmarks` permission and replaces the mute-tab command.
- Optional background vibrancy is enabled by default and toggleable from the popup.

<sup>Written for commit 1aabe3e088fc583f8214a17472068c086c4096ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DeepanshuMishraa/jump/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Bookmark Manager with search, folder filtering, sorting, keyboard navigation, and bookmark opening.
  * Added an Alt+B shortcut for opening bookmarks.
  * Added Background Vibrancy and bookmark mouse-navigation settings.
  * Added Alt/Option-drag support for repositioning the command palette, with snapping and a shortcut reference.

* **Improvements**
  * Improved tab previews with on-demand loading, caching, and faster updates.
  * Prevented the palette from appearing in captured previews.
  * Updated scrolling, transitions, and transparency fallbacks for smoother interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->