### PR TITLE
fixes

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -375,7 +375,6 @@ chrome.commands.onCommand.addListener((command) => {
   if (command === "open-palette") void openSearchPalette();
   if (command === "open-tab-switcher") void openTabSwitcher();
   if (command === "pin-tab") void sendToActiveTab({ type: "request-pin-selected-tab" });
-  if (command === "mute-tab") void sendToActiveTab({ type: "request-mute-selected-tab" });
   if (command === "open-bookmarks") void sendToActiveTab({ type: "open-palette", mode: "bookmarks" });
 });
 

--- a/src/components/BookmarkManager.tsx
+++ b/src/components/BookmarkManager.tsx
@@ -93,11 +93,12 @@ export function BookmarkManager({
     const normalized = query.trim().toLowerCase();
     return bookmarks
       .filter((bookmark) => {
-        if (selectedFolder && !bookmark.folderPath.includes(selectedFolder)) {
+        if (selectedFolder && !bookmark.folderPath.some((folder) => folder.trim() === selectedFolder)) {
           return false;
         }
         if (!normalized) return true;
-        const matchable = `${bookmark.title} ${bookmark.url} ${bookmark.folderPath.join(" ")}`.toLowerCase();
+        const normalizedFolders = bookmark.folderPath.map((folder) => folder.trim()).join(" ");
+        const matchable = `${bookmark.title} ${bookmark.url} ${normalizedFolders}`.toLowerCase();
         return matchable.includes(normalized);
       })
       .sort((a, b) => (b.dateAdded ?? 0) - (a.dateAdded ?? 0));
@@ -281,6 +282,7 @@ export function BookmarkManager({
           cycleFolderRef.current("next");
         }
       } else if (event.key === "Enter") {
+        if (event.target instanceof HTMLButtonElement) return;
         event.preventDefault();
         const target = filteredBookmarksRef.current[selectedIndexRef.current];
         if (target) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1849,6 +1849,11 @@ kbd {
 }
 
 @media (prefers-reduced-transparency: reduce) {
+  .palette-backdrop[data-vibrancy="on"] {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
   .palette-backdrop[data-vibrancy="on"] .palette-card,
   .palette-backdrop[data-vibrancy="on"] .bookmark-card {
     background: var(--bg-panel);
@@ -1879,15 +1884,21 @@ kbd {
   .switcher-card,
   .gallery-card,
   .list-row,
+  .bookmark-scope-pill,
   .popup-segmented-item,
   .popup-settings-link {
     transition: none;
+  }
+
+  .bookmark-card.is-closing {
+    animation: none;
   }
 
   .switcher-card,
   .switcher-card:hover,
   .switcher-card.is-selected,
   .switcher-card:active,
+  .bookmark-scope-pill:active,
   .gallery-card,
   .gallery-card:hover,
   .gallery-card.selected,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes bookmark manager filtering to use exact folder names, prevents Enter from triggering actions when a button is focused, and applies reduced-transparency styles to the palette backdrop and bookmark scope pill. Also removes the unused mute-tab keyboard command.

<sup>Written for commit 9732b1a4d124b9b8b265e3b6e09eda8b9b186734. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DeepanshuMishraa/jump/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

