### PR TITLE
fix(palette): remove trailing arrow transition on command palette rows

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1030,7 +1030,6 @@ button {
   height: 22px;
   border-radius: 6px;
   color: var(--text-muted);
-  transition: all 120ms ease;
 }
 
 .list-row.selected .list-row-action {


### PR DESCRIPTION
Fixes #10

### Summary
Removes `transition: all 120ms ease` from `.action-arrow-badge`.

### Problem
When stepping through options in the command palette, unselected rows apply `visibility: hidden` via `.list-row:not(.selected) .list-row-action`. Because `.action-arrow-badge` defined `transition: all 120ms ease`, CSS visibility transitioned over 120ms (remaining visible during interpolation) while fading background, color, and box-shadow. This caused an isolated arrow badge to linger on the previously selected item.

### Solution
Removing the transition on `.action-arrow-badge` ensures the action indicator hides immediately upon deselection in sync with the action text.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the CSS transition on the command palette arrow badge so the arrow hides immediately when a row is deselected, matching the action text instead of lingering for 120ms. Fixes #10.

<sup>Written for commit 41bb88c94bd462f775986ba988a8912696ffb454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DeepanshuMishraa/jump/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

